### PR TITLE
Support recursive schemas

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -39,6 +39,7 @@ function Validator(opts) {
 
 	// Load rules
 	this.rules = loadRules();
+	this.cache = new Map();
 }
 
 /**
@@ -134,6 +135,14 @@ Validator.prototype.compileSchemaType = function(schemaType) {
 };
 
 Validator.prototype.compileSchemaRule = function(schemaRule) {
+	const compiledRule = {};
+	const cachedResult = this.cache.get(schemaRule);
+	if (cachedResult) {
+		return cachedResult;
+	} else {
+		this.cache.set(schemaRule, compiledRule);
+	}
+
 	if (typeof schemaRule === "string") {
 		schemaRule = {
 			type: schemaRule
@@ -156,12 +165,12 @@ Validator.prototype.compileSchemaRule = function(schemaRule) {
 		dataFunction = this.checkSchemaArray;
 	}
 
-	return {
+	return Object.assign(compiledRule, {
 		schemaRule: schemaRule,
 		ruleFunction: ruleFunction,
 		dataFunction: dataFunction,
 		dataParameter: dataParameter
-	};
+	});
 };
 
 Validator.prototype.checkSchemaObject = function(value, compiledObject, path, parent) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -68,12 +68,14 @@ Validator.prototype.compile = function(schema) {
 		}
 
 		const rules = this.compileSchemaType(schema);
+		this.cache.clear();
 		return function(value) {
 			return self.checkSchemaType(value, rules, undefined, null);
 		};
 	} 
 
 	const rule = this.compileSchemaObject(schema);
+	this.cache.clear();
 	return function(value) {
 		return self.checkSchemaObject(value, rule, undefined, null);
 	};
@@ -84,26 +86,32 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 		throw new Error("Invalid schema!");
 	}
 
-	const compiledObject = Object.keys(schemaObject).map(name => {
+	let compiledObject = this.cache.get(schemaObject);
+	if (compiledObject) {
+		compiledObject.cycle = true;
+		return compiledObject;
+	} else{
+		compiledObject = { cycle: false, properties: null, compiledObjectFunction: null, objectStack: [] };
+		this.cache.set(schemaObject, compiledObject);
+	}
+
+	compiledObject.properties = Object.keys(schemaObject).map(name => {
 		const compiledType = this.compileSchemaType(schemaObject[name]);
 		return {name: name, compiledType: compiledType};
 	});
-
-	// Uncomment this line to use compiled object validator:
-	// return compiledObject;
 
 	const sourceCode = [];
 	sourceCode.push("let res;");
 	sourceCode.push("let propertyPath;");
 	sourceCode.push("const errors = [];");
-	for (let i = 0; i < compiledObject.length; i++) {
-		const property = compiledObject[i];
+	for (let i = 0; i < compiledObject.properties.length; i++) {
+		const property = compiledObject.properties[i];
 		const name = property.name;
 		sourceCode.push(`propertyPath = (path !== undefined ? path + ".${name}" : "${name}");`);
 		if (Array.isArray(property.compiledType)) {
-			sourceCode.push(`res = this.checkSchemaType(value.${name}, compiledObject[${i}].compiledType, propertyPath, value);`);
+			sourceCode.push(`res = this.checkSchemaType(value.${name}, properties[${i}].compiledType, propertyPath, value);`);
 		} else {
-			sourceCode.push(`res = this.checkSchemaRule(value.${name}, compiledObject[${i}].compiledType, propertyPath, value);`);
+			sourceCode.push(`res = this.checkSchemaRule(value.${name}, properties[${i}].compiledType, propertyPath, value);`);
 		}
 		sourceCode.push("if (res !== true) {");
 		sourceCode.push("\tthis.handleResult(errors, propertyPath, res);");
@@ -112,12 +120,9 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 
 	sourceCode.push("return errors.length === 0 ? true : errors;");
 
-	const compiledObjectFunction = new Function("value", "compiledObject", "path", "parent", sourceCode.join("\n"));
+	compiledObject.compiledObjectFunction = new Function("value", "properties", "path", "parent", sourceCode.join("\n"));
 
-	const self = this;
-	return function(value, _unused, path, parent) {
-		return compiledObjectFunction.call(self, value, compiledObject, path, parent);
-	};
+	return compiledObject;
 };
 
 Validator.prototype.compileSchemaType = function(schemaType) {
@@ -135,14 +140,6 @@ Validator.prototype.compileSchemaType = function(schemaType) {
 };
 
 Validator.prototype.compileSchemaRule = function(schemaRule) {
-	const compiledRule = {};
-	const cachedResult = this.cache.get(schemaRule);
-	if (cachedResult) {
-		return cachedResult;
-	} else {
-		this.cache.set(schemaRule, compiledRule);
-	}
-
 	if (typeof schemaRule === "string") {
 		schemaRule = {
 			type: schemaRule
@@ -165,25 +162,41 @@ Validator.prototype.compileSchemaRule = function(schemaRule) {
 		dataFunction = this.checkSchemaArray;
 	}
 
-	return Object.assign(compiledRule, {
+	return {
 		schemaRule: schemaRule,
 		ruleFunction: ruleFunction,
 		dataFunction: dataFunction,
 		dataParameter: dataParameter
-	});
+	};
 };
 
 Validator.prototype.checkSchemaObject = function(value, compiledObject, path, parent) {
-	if (compiledObject instanceof Function) {
-		return compiledObject(value, undefined, path, parent);
+	if (compiledObject.cycle) {
+		if (compiledObject.objectStack.indexOf(value) !== -1) {
+			return true;
+		}
+
+		compiledObject.objectStack.push(value);
+		const result = this.checkSchemaObjectInner(value, compiledObject, path, parent);
+		compiledObject.objectStack.pop();
+		return result;
+	} else {
+		return this.checkSchemaObjectInner(value, compiledObject, path, parent);
 	}
+};
+
+Validator.prototype.checkSchemaObjectInner = function(value, compiledObject, path, parent) {
+	return compiledObject.compiledObjectFunction.call(this, value, compiledObject.properties, path, parent);
+
+	/*
+	// Reference implementation of the object checker
 
 	const errors = [];
-	const checksLength = compiledObject.length;
-	for (let i = 0; i < checksLength; i++) {
-		const check = compiledObject[i];
-		const propertyPath = (path !== undefined ? path + "." : "") + check.name;
-		const res = this.checkSchemaType(value[check.name], check.compiledType, propertyPath, value);
+	const propertiesLength = compiledObject.properties.length;
+	for (let i = 0; i < propertiesLength; i++) {
+		const property = compiledObject.properties[i];
+		const propertyPath = (path !== undefined ? path + "." : "") + property.name;
+		const res = this.checkSchemaType(value[property.name], property.compiledType, propertyPath, value);
 
 		if (res !== true) {
 			this.handleResult(errors, propertyPath, res);
@@ -191,6 +204,7 @@ Validator.prototype.checkSchemaObject = function(value, compiledObject, path, pa
 	}
 
 	return errors.length === 0 ? true : errors;
+	*/
 };
 
 Validator.prototype.checkSchemaType = function(value, compiledType, path, parent) {

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -1004,3 +1004,35 @@ describe("Test array without items", () => {
 		expect(res).toBe(true);
 	});
 });
+
+describe("Test recursive schema", () => {
+	const v = new Validator();
+
+	let schema = {};
+	Object.assign(schema, {
+		name: { type: "string" },
+		subcategories: {
+			type: "array",
+			optional: true,
+			items: { type: "object", props: schema}
+		}
+	});
+
+	it("should compile and validate", () => {
+		let category = {
+			name: "top",
+			subcategories: [
+				{
+					name: "sub1"
+				},
+				{
+					name: "sub2"
+				}
+			]
+		};
+
+		let res = v.validate(category, schema);
+
+		expect(res).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #30

Currently the cache holds references to all schema rules for the lifetime of the validator. Should probably clear the cache after each compile to prevent leaks in long-running programs, but haven't made up my mind yet.