### PR TITLE
The compiled "checker" should accept path & parent

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -97,15 +97,15 @@ Validator.prototype.compile = function(schema) {
 
 		const rules = this.compileSchemaType(schema);
 		this.cache.clear();
-		return function(value) {
-			return self.checkSchemaType(value, rules, undefined, null);
+		return function(value, path, parent) {
+			return self.checkSchemaType(value, rules, path, parent || null);
 		};
 	} 
 
 	const rule = this.compileSchemaObject(schema);
 	this.cache.clear();
-	return function(value) {
-		return self.checkSchemaObject(value, rule, undefined, null);
+	return function(value, path, parent) {
+		return self.checkSchemaObject(value, rule, path, parent || null);
 	};
 };
 

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -301,6 +301,63 @@ describe("Test compile (integration test)", () => {
 
 	});
 
+	describe("Test check generator with custom path & parent", () => {
+
+		it("when schema is defined as an array, and custom path & parent are specified, they should be forwarded to validators", () => {
+			const v = new Validator();
+			const customValidator = jest.fn().mockReturnValue(true);	// Will be called with (value, schema, path, parent)
+			v.add("customValidator", customValidator);
+
+			const validate = v.compile([{ type: "customValidator" }]);
+			const parent = {};
+			const res = validate({ customValue: 4711 }, "customPath", parent);
+
+			expect(res).toBe(true);
+			expect(customValidator.mock.calls[0][2]).toBe("customPath");
+			expect(customValidator.mock.calls[0][3]).toBe(parent);
+		});
+
+		it("when schema is defined as an array, path & parent should be set to default values in validators", () => {
+			const v = new Validator();
+			const customValidator = jest.fn().mockReturnValue(true);	// Will be called with (value, schema, path, parent)
+			v.add("customValidator", customValidator);
+
+			const validate = v.compile([{ type: "customValidator" }]);
+			const res = validate({ customValue: 4711 });
+
+			expect(res).toBe(true);
+			expect(customValidator.mock.calls[0][2]).toBeUndefined();
+			expect(customValidator.mock.calls[0][3]).toBeNull();
+		});
+
+		it("when schema is defined as an object, and custom path is specified, it should be forwarded to validators", () => {
+			// Note: as the item we validate always must be an object, there is no use
+			// of specifying a custom parent, like for the schema-as-array above. 
+			// The parent is currently used in the validator code (only forwarded to the generated
+			// function that validates all properties) and there is no way to test it.
+			const v = new Validator();
+			const customValidator = jest.fn().mockReturnValue(true);	// Will be called with (value, schema, path, parent)
+			v.add("customValidator", customValidator);
+
+			const validate = v.compile({ customValue: { type: "customValidator" } });
+			const res = validate({ customValue: 4711 }, "customPath");
+
+			expect(res).toBe(true);
+			expect(customValidator.mock.calls[0][2]).toBe("customPath.customValue");
+		});
+
+		it("when schema is defined as an object, path should be set to default value in validators", () => {
+			const v = new Validator();
+			const customValidator = jest.fn().mockReturnValue(true);	// Will be called with (value, schema, path, parent)
+			v.add("customValidator", customValidator);
+
+			const validate = v.compile({ customValue: { type: "customValidator" } });
+			const res = validate({ customValue: 4711 });
+
+			expect(res).toBe(true);
+			expect(customValidator.mock.calls[0][2]).toBe("customValue");
+		});
+	});
 });
 
 describe("Test nested schema", () => {


### PR DESCRIPTION
### Previous functionality
In 0.3.0 - 0.6.10 the returned function from _compile_ looked like this:

``` js
function(obj, _schema, pathStack)
```

> 0.3.0: https://github.com/icebob/fastest-validator/blob/v0.3.0/lib/validator.js#L128
> 0.6.10: https://github.com/icebob/fastest-validator/blob/v0.6.10/lib/validator.js#L169

`_schema` was never used but `pathStack` was, so it was possible to provide a custom path from code:

``` js
const v = new Validator()
const validate =  v.compile(schema)
const result = validate(myObject, null, 'custom.path')
```

The custom path was used in error messages and also become part of the path forwarded to custom validators, so they could use that info when validating. 

### Current functionality: Breaking change
In 0.6.11 this was changed to:

``` js
function(value)
```

This was **breaking change** and broke some of our tests, where we use fastest-validator to validate parts of the objects. Custom validators that relies on path in the same way as the example above are used. Currently we have locked to use version 0.6.10

### Restored functionality

This PR brings back the 0.6.10 functionality, however;  As a breaking change already was introduced in 0.6.11, instead of restoring 0.6.10 functionality as it was (with an unused `_schema` argument) the returned function now looks like this.

``` js
function(value, path, parent)
```

So it's still a breaking change to what 0.6.10 looked like, but at least it makes it possible, after changing calls from `validate(myObject, null, 'custom.path')` to `validate(myObject, 'custom.path')`, to provide custom paths.

### Tests
Tests have been added that verifies

- that `path`, and when calling compile with schemas in an array: `parent` is used.
- that calling the returned checker, without `path` and `parent`, still works.

**To be clear**: This PR introduces no breaking changes to 0.6.12

