### PR TITLE
Implement to return sanitized object

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
 			"request": "launch",
 			"name": "Launch benchmark",
 			"program": "${workspaceRoot}\\benchmark\\index.js",
-			"args": [ "simple" ]
+			"args": [ "sanitize" ]
 		},
 		{
 			"type": "node",

--- a/benchmark/suites/sanitize.js
+++ b/benchmark/suites/sanitize.js
@@ -1,0 +1,74 @@
+"use strict";
+
+const Benchmarkify = require("benchmarkify");
+const benchmark = new Benchmarkify("Fastest validator benchmark").printHeader();
+
+let bench = benchmark.createSuite("Sanitize simple object");
+
+const Validator = require("../../index");
+const v = new Validator();
+
+const obj = {
+	name: "John Doe",
+	email: "john.doe@company.space",
+	firstName: "John",
+	phone: "123-4567",
+	age: "33",
+	status: 1
+};
+
+const schema = {
+	name: {
+		type: "string",
+		min: 4,
+		max: 25
+	},
+	email: { type: "email" },
+	firstName: { type: "string" },
+	phone: { type: "string" },
+	age: {
+		type: "number",
+		min: 18,
+		convert: true
+	},
+	status: { type: "boolean", convert: true }
+};
+
+
+let check = v.compile(schema);
+
+bench.add("validate & sanitize", () => {
+	let converted = {};
+	let res = check(obj, null, null, converted);
+	if (res !== true)
+		throw new Error("Validation error!", res);
+});
+
+
+bench.run();
+
+
+/*
+
+===============================
+  Fastest validator benchmark
+===============================
+
+Platform info:
+==============
+   Windows_NT 6.1.7601 x64
+   Node.JS: 8.11.0
+   V8: 6.2.414.50
+   Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz × 8
+
+Suite: Simple object
+√ compile & validate                        1,115,239 rps
+√ validate with pre-compiled schema         3,986,017 rps
+√ validate with wrong obj                     704,992 rps
+
+   compile & validate (#)                       0%      (1,115,239 rps)   (avg: 896ns)
+   validate with pre-compiled schema      +257.41%      (3,986,017 rps)   (avg: 250ns)
+   validate with wrong obj                 -36.79%        (704,992 rps)   (avg: 1μs)
+-----------------------------------------------------------------------
+
+*/

--- a/lib/rules/boolean.js
+++ b/lib/rules/boolean.js
@@ -1,22 +1,29 @@
 "use strict";
 
-module.exports = function checkBoolean(value, schema) {
+module.exports = function checkBoolean(value, schema, _unused1, _unused2, converted) {
 	if (schema.convert === true && typeof value !== "boolean") {
-		if (
-			value === 1
-		|| value === 0
-		|| value === "true"
-		|| value === "false"
-		|| value === "1"
-		|| value === "0"
-		|| value === "on"
-		|| value === "off"
-		) 
-			return true;
+		switch (value) {
+			case 1:
+			case "1":
+			case "true":
+			case "on":
+				value = true;
+				break;
+			case 0:
+			case "0":
+			case "false":
+			case "off":
+				value = false;
+				break;
+		}
 	}
-	
+
 	if (typeof value !== "boolean") {
 		return this.makeError("boolean");
+	}
+
+	if (schema.convert === true && converted !== undefined) {
+		converted.value = value;
 	}
 
 	return true;

--- a/lib/rules/boolean.js
+++ b/lib/rules/boolean.js
@@ -3,18 +3,18 @@
 module.exports = function checkBoolean(value, schema, _unused1, _unused2, converted) {
 	if (schema.convert === true && typeof value !== "boolean") {
 		switch (value) {
-			case 1:
-			case "1":
-			case "true":
-			case "on":
-				value = true;
-				break;
-			case 0:
-			case "0":
-			case "false":
-			case "off":
-				value = false;
-				break;
+		case 1:
+		case "1":
+		case "true":
+		case "on":
+			value = true;
+			break;
+		case 0:
+		case "0":
+		case "false":
+		case "off":
+			value = false;
+			break;
 		}
 	}
 

--- a/lib/rules/custom.js
+++ b/lib/rules/custom.js
@@ -1,5 +1,5 @@
 "use strict";
 
-module.exports = function customCheck(value, schema) {
-	return schema.check.call(this, value, schema);
+module.exports = function customCheck(value, schema, _unused1, _unused2, converted) {
+	return schema.check.call(this, value, schema, converted);
 };

--- a/lib/rules/date.js
+++ b/lib/rules/date.js
@@ -1,6 +1,6 @@
 "use strict";
 
-module.exports = function checkDate(value, schema) {
+module.exports = function checkDate(value, schema, _unused1, _unused2, converted) {
 	if (schema.convert === true && !(value instanceof Date)) {
 		value = new Date(value);
 	}
@@ -11,6 +11,10 @@ module.exports = function checkDate(value, schema) {
 
 	if (isNaN(value.getTime())) {
 		return this.makeError("date");
+	}
+
+	if (schema.convert === true && converted !== undefined) {
+		converted.value = value;
 	}
 
 	return true;

--- a/lib/rules/number.js
+++ b/lib/rules/number.js
@@ -1,6 +1,6 @@
 "use strict";
 
-module.exports = function checkNumber(value, schema) {
+module.exports = function checkNumber(value, schema, _unused1, _unused2, converted) {
 	if (schema.convert === true && typeof value !== "number") {
 		value = Number(value);
 	}
@@ -44,6 +44,10 @@ module.exports = function checkNumber(value, schema) {
 	// Check negative
 	if (schema.negative === true && value >= 0) {
 		return this.makeError("numberNegative", value);
+	}
+
+	if (schema.convert === true && converted !== undefined) {
+		converted.value = value;
 	}
 
 	return true;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -189,7 +189,7 @@ Validator.prototype.generateCheckSchemaObject = function(sourceCode, properties,
 			sourceCode.push(`\t\tresult${propertyValueExpr} = propertyResult.value;`);
 			sourceCode.push("\t} else {");
 			sourceCode.push(`\t\tif (value${propertyValueExpr} !== undefined && value${propertyValueExpr} !== null) {`);
-			sourceCode.push(`\t\t\tresult${propertyValueExpr} = propertyValue;`);
+			sourceCode.push(`\t\t\tresult${propertyValueExpr} = value${propertyValueExpr};`);
 			sourceCode.push("\t\t}");
 			sourceCode.push("\t}");
 			sourceCode.push("}");
@@ -428,6 +428,10 @@ Validator.prototype.checkSchemaRule = function(value, compiledRule, path, parent
 
 	if (compiledRule.dataFunction !== null) {
 		return compiledRule.dataFunction.call(this, value, compiledRule.dataParameter, path, parent, converted);
+	}
+
+	if (converted !== undefined && converted.value === undefined) {
+		converted.value = value;
 	}
 
 	return true;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -99,15 +99,15 @@ Validator.prototype.compile = function(schema) {
 
 		const rules = this.compileSchemaType(schema);
 		this.cache.clear();
-		return function(value, path, parent) {
-			return self.checkSchemaType(value, rules, path, parent || null);
+		return function(value, path, parent, converted) {
+			return self.checkSchemaType(value, rules, path, parent || null, converted);
 		};
 	}
 
 	const rule = this.compileSchemaObject(schema);
 	this.cache.clear();
-	return function(value, path, parent) {
-		return self.checkSchemaObject(value, rule, path, parent || null);
+	return function(value, path, parent, converted) {
+		return self.checkSchemaObject(value, rule, path, parent || null, converted);
 	};
 };
 
@@ -134,27 +134,50 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 	});
 
 	const sourceCode = [];
+	this.generateCheckSchemaObject(sourceCode, compiledObject.properties, strict);
+
+	compiledObject.compiledObjectFunction = new Function("value", "properties", "path", "parent", "converted", sourceCode.join("\n"));
+
+	return compiledObject;
+};
+
+Validator.prototype.generateCheckSchemaObject = function(sourceCode, properties, strict) {
+
 	sourceCode.push("let res;");
 	sourceCode.push("let propertyPath;");
-	sourceCode.push("const errors = [];");
+	sourceCode.push("let propertyResult;");
+	sourceCode.push("const errors = [];");	
+	sourceCode.push("const result = converted !== undefined ? {} : undefined;");
 
 	if (strict === true) {
 		sourceCode.push("const givenProps = new Map(Object.keys(value).map(key => [key, true]));");
 	}
 
-	for (let i = 0; i < compiledObject.properties.length; i++) {
-		const property = compiledObject.properties[i];
+	for (let i = 0; i < properties.length; i++) {
+		const property = properties[i];
 		const name = escapeEvalString(property.name);
-		const propertyValueExpr = identifierRegex.test(name) ? `value.${name}` : `value["${name}"]`;
+		const propertyValueExpr = identifierRegex.test(name) ? `.${name}` : `["${name}"]`;
 
 		sourceCode.push(`propertyPath = (path !== undefined ? path + ".${name}" : "${name}");`);
+
+		sourceCode.push("propertyResult = converted !== undefined ? {} : undefined;");
+
 		if (Array.isArray(property.compiledType)) {
-			sourceCode.push(`res = this.checkSchemaType(${propertyValueExpr}, properties[${i}].compiledType, propertyPath, value);`);
+			sourceCode.push(`res = this.checkSchemaType(value${propertyValueExpr}, properties[${i}].compiledType, propertyPath, value, propertyResult);`);
 		} else {
-			sourceCode.push(`res = this.checkSchemaRule(${propertyValueExpr}, properties[${i}].compiledType, propertyPath, value);`);
+			sourceCode.push(`res = this.checkSchemaRule(value${propertyValueExpr}, properties[${i}].compiledType, propertyPath, value, propertyResult);`);
 		}
+
 		sourceCode.push("if (res !== true) {");
 		sourceCode.push(`\tthis.handleResult(errors, propertyPath, res, properties[${i}].compiledType.messages);`);
+		sourceCode.push("} else if (converted !== undefined) {");
+		sourceCode.push("\tif (propertyResult.value !== undefined) {");
+		sourceCode.push(`\t\tresult${propertyValueExpr} = propertyResult.value;`);
+		sourceCode.push("\t} else {");
+		sourceCode.push(`\t\tif (value${propertyValueExpr} !== undefined && value${propertyValueExpr} !== null) {`);
+		sourceCode.push(`\t\t\tresult${propertyValueExpr} = propertyValue;`);
+		sourceCode.push("\t\t}");
+		sourceCode.push("\t}");
 		sourceCode.push("}");
 
 		if (strict === true) {
@@ -168,11 +191,15 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 		sourceCode.push("}");
 	}
 
-	sourceCode.push("return errors.length === 0 ? true : errors;");
+	sourceCode.push("if (errors.length > 0) {");
+	sourceCode.push("\treturn errors;");
+	sourceCode.push("}");
 
-	compiledObject.compiledObjectFunction = new Function("value", "properties", "path", "parent", sourceCode.join("\n"));
+	sourceCode.push("if (converted !== undefined) {");
+	sourceCode.push("\tconverted.value = result;");
+	sourceCode.push("}");
 
-	return compiledObject;
+	sourceCode.push("return true;");
 };
 
 Validator.prototype.compileSchemaType = function(schemaType) {
@@ -241,44 +268,62 @@ Validator.prototype.compileSchemaRule = function(schemaRule) {
 	};
 };
 
-Validator.prototype.checkSchemaObject = function(value, compiledObject, path, parent) {
+Validator.prototype.checkSchemaObject = function(value, compiledObject, path, parent, converted) {
 	if (compiledObject.cycle) {
 		if (compiledObject.objectStack.indexOf(value) !== -1) {
 			return true;
 		}
 
 		compiledObject.objectStack.push(value);
-		const result = this.checkSchemaObjectInner(value, compiledObject, path, parent);
+		const result = this.checkSchemaObjectInner(value, compiledObject, path, parent, converted);
 		compiledObject.objectStack.pop();
 		return result;
 	} else {
-		return this.checkSchemaObjectInner(value, compiledObject, path, parent);
+		return this.checkSchemaObjectInner(value, compiledObject, path, parent, converted);
 	}
 };
 
-Validator.prototype.checkSchemaObjectInner = function(value, compiledObject, path, parent) {
-	return compiledObject.compiledObjectFunction.call(this, value, compiledObject.properties, path, parent);
+Validator.prototype.checkSchemaObjectInner = function(value, compiledObject, path, parent, converted) {
+	return compiledObject.compiledObjectFunction.call(this, value, compiledObject.properties, path, parent, converted);
 
 	/*
     // Reference implementation of the object checker
 
-    const errors = [];
-    const propertiesLength = compiledObject.properties.length;
-    for (let i = 0; i < propertiesLength; i++) {
-    const property = compiledObject.properties[i];
-    const propertyPath = (path !== undefined ? path + "." : "") + property.name;
-    const res = this.checkSchemaType(value[property.name], property.compiledType, propertyPath, value);
+	const errors = [];
+	const result = converted !== undefined ? {} : undefined;
+	for (let i = 0; i < compiledObject.properties.length; i++) {
+		const property = compiledObject.properties[i];
+		const propertyPath = (path !== undefined ? path + "." : "") + property.name;
+		const propertyResult = converted !== undefined ? {} : undefined;
+		const res = this.checkSchemaType(value[property.name], property.compiledType, propertyPath, value, propertyResult);
 
-    if (res !== true) {
-    this.handleResult(errors, propertyPath, res);
-    }
-    }
+		if (res !== true) {
+			this.handleResult(errors, propertyPath, res);
+		} else if (converted !== undefined) {
+			if (propertyResult.value !== undefined) {
+				result[property.name] = propertyResult.value;
+			} else {
+				const propertyValue = value[property.name];
+				if (propertyValue !== undefined && propertyValue !== null) {
+					result[property.name] = propertyValue;
+				}
+			}
+		}
+	}
 
-    return errors.length === 0 ? true : errors;
-    */
+	if (errors.length > 0) {
+		return errors;
+	}
+
+	if (converted !== undefined) {
+		converted.value = result;
+	}
+
+	return true;
+	*/
 };
 
-Validator.prototype.checkSchemaType = function(value, compiledType, path, parent) {
+Validator.prototype.checkSchemaType = function(value, compiledType, path, parent, converted) {
 
 	if (Array.isArray(compiledType)) {
 
@@ -286,7 +331,7 @@ Validator.prototype.checkSchemaType = function(value, compiledType, path, parent
 		const checksLength = compiledType.length;
 		for (let i = 0; i < checksLength; i++) {
 			// Always compiled to list of rules
-			const res = this.checkSchemaRule(value, compiledType[i], path, parent);
+			const res = this.checkSchemaRule(value, compiledType[i], path, parent, converted);
 
 			if (res !== true) {
 				this.handleResult(errors, path, res, compiledType.messages);
@@ -299,26 +344,35 @@ Validator.prototype.checkSchemaType = function(value, compiledType, path, parent
 		return errors;
 	}
 
-	return this.checkSchemaRule(value, compiledType, path, parent);
+	return this.checkSchemaRule(value, compiledType, path, parent, converted);
 };
 
-Validator.prototype.checkSchemaArray = function(value, compiledArray, path, parent) {
+Validator.prototype.checkSchemaArray = function(value, compiledArray, path, parent, converted) {
 	const errors = [];
+	const result = converted !== undefined ? [] : undefined;
 	const valueLength = value.length;
-
 	for (let i = 0; i < valueLength; i++) {
 		const itemPath = (path !== undefined ? path : "") + "[" + i + "]";
-		const res = this.checkSchemaType(value[i], compiledArray, itemPath, value, parent);
+		const itemResult = converted !== undefined ? {} : undefined;
+		const res = this.checkSchemaType(value[i], compiledArray, itemPath, value, itemResult);
 
-		if (res !== true) {
+		if (res === true) {
+			if (converted !== undefined) {
+				result.push(itemResult.value !== undefined ? itemResult.value : value[i]);
+			}
+		} else {
 			this.handleResult(errors, itemPath, res, compiledArray.messages);
 		}
+	}
+
+	if (converted !== undefined) {
+		converted.value = result;
 	}
 
 	return errors.length === 0 ? true : errors;
 };
 
-Validator.prototype.checkSchemaRule = function(value, compiledRule, path, parent) {
+Validator.prototype.checkSchemaRule = function(value, compiledRule, path, parent, converted) {
 	const schemaRule = compiledRule.schemaRule;
 
 	if (value === undefined || value === null) {
@@ -334,7 +388,7 @@ Validator.prototype.checkSchemaRule = function(value, compiledRule, path, parent
 		return errors;
 	}
 
-	const res = compiledRule.ruleFunction.call(this, value, schemaRule, path, parent);
+	const res = compiledRule.ruleFunction.call(this, value, schemaRule, path, parent, converted);
 
 	if (res !== true) {
 		const errors = [];
@@ -344,7 +398,7 @@ Validator.prototype.checkSchemaRule = function(value, compiledRule, path, parent
 	}
 
 	if (compiledRule.dataFunction !== null) {
-		return compiledRule.dataFunction.call(this, value, compiledRule.dataParameter, path, parent);
+		return compiledRule.dataFunction.call(this, value, compiledRule.dataParameter, path, parent, converted);
 	}
 
 	return true;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -100,14 +100,14 @@ Validator.prototype.compile = function(schema) {
 		const rules = this.compileSchemaType(schema);
 		this.cache.clear();
 		return function(value, path, parent, converted) {
-			return self.checkSchemaType(value, rules, path, parent || null, converted);
+			return self.checkSchemaType(value, rules, path || undefined, parent || null, converted);
 		};
 	}
 
 	const rule = this.compileSchemaObject(schema);
 	this.cache.clear();
 	return function(value, path, parent, converted) {
-		return self.checkSchemaObject(value, rule, path, parent || null, converted);
+		return self.checkSchemaObject(value, rule, path || undefined, parent || null, converted);
 	};
 };
 
@@ -134,20 +134,29 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 	});
 
 	const sourceCode = [];
-	this.generateCheckSchemaObject(sourceCode, compiledObject.properties, strict);
+	
+	sourceCode.push("if (converted !== undefined) {");
+	this.generateCheckSchemaObject(sourceCode, compiledObject.properties, strict, true);
+	sourceCode.push("} else {");
+	this.generateCheckSchemaObject(sourceCode, compiledObject.properties, strict, false);
+	sourceCode.push("}");
 
 	compiledObject.compiledObjectFunction = new Function("value", "properties", "path", "parent", "converted", sourceCode.join("\n"));
 
 	return compiledObject;
 };
 
-Validator.prototype.generateCheckSchemaObject = function(sourceCode, properties, strict) {
+Validator.prototype.generateCheckSchemaObject = function(sourceCode, properties, strict, withConverted) {
 
 	sourceCode.push("let res;");
 	sourceCode.push("let propertyPath;");
-	sourceCode.push("let propertyResult;");
+	if (withConverted) {
+		sourceCode.push("let propertyResult;");
+		sourceCode.push("const result = {};");
+	} else {
+		sourceCode.push("const propertyResult = undefined;");
+	}
 	sourceCode.push("const errors = [];");	
-	sourceCode.push("const result = converted !== undefined ? {} : undefined;");
 
 	if (strict === true) {
 		sourceCode.push("const givenProps = new Map(Object.keys(value).map(key => [key, true]));");
@@ -160,7 +169,9 @@ Validator.prototype.generateCheckSchemaObject = function(sourceCode, properties,
 
 		sourceCode.push(`propertyPath = (path !== undefined ? path + ".${name}" : "${name}");`);
 
-		sourceCode.push("propertyResult = converted !== undefined ? {} : undefined;");
+		if (withConverted) {
+			sourceCode.push("propertyResult = {};");
+		}
 
 		if (Array.isArray(property.compiledType)) {
 			sourceCode.push(`res = this.checkSchemaType(value${propertyValueExpr}, properties[${i}].compiledType, propertyPath, value, propertyResult);`);
@@ -170,15 +181,19 @@ Validator.prototype.generateCheckSchemaObject = function(sourceCode, properties,
 
 		sourceCode.push("if (res !== true) {");
 		sourceCode.push(`\tthis.handleResult(errors, propertyPath, res, properties[${i}].compiledType.messages);`);
-		sourceCode.push("} else if (converted !== undefined) {");
-		sourceCode.push("\tif (propertyResult.value !== undefined) {");
-		sourceCode.push(`\t\tresult${propertyValueExpr} = propertyResult.value;`);
-		sourceCode.push("\t} else {");
-		sourceCode.push(`\t\tif (value${propertyValueExpr} !== undefined && value${propertyValueExpr} !== null) {`);
-		sourceCode.push(`\t\t\tresult${propertyValueExpr} = propertyValue;`);
-		sourceCode.push("\t\t}");
-		sourceCode.push("\t}");
 		sourceCode.push("}");
+
+		if (withConverted) {
+			sourceCode.push("else {");
+			sourceCode.push("\tif (propertyResult.value !== undefined) {");
+			sourceCode.push(`\t\tresult${propertyValueExpr} = propertyResult.value;`);
+			sourceCode.push("\t} else {");
+			sourceCode.push(`\t\tif (value${propertyValueExpr} !== undefined && value${propertyValueExpr} !== null) {`);
+			sourceCode.push(`\t\t\tresult${propertyValueExpr} = propertyValue;`);
+			sourceCode.push("\t\t}");
+			sourceCode.push("\t}");
+			sourceCode.push("}");
+		}
 
 		if (strict === true) {
 			sourceCode.push(`givenProps.delete("${name}");`);
@@ -195,9 +210,9 @@ Validator.prototype.generateCheckSchemaObject = function(sourceCode, properties,
 	sourceCode.push("\treturn errors;");
 	sourceCode.push("}");
 
-	sourceCode.push("if (converted !== undefined) {");
-	sourceCode.push("\tconverted.value = result;");
-	sourceCode.push("}");
+	if (withConverted) {
+		sourceCode.push("\tconverted.value = result;");
+	}
 
 	sourceCode.push("return true;");
 };
@@ -349,27 +364,41 @@ Validator.prototype.checkSchemaType = function(value, compiledType, path, parent
 
 Validator.prototype.checkSchemaArray = function(value, compiledArray, path, parent, converted) {
 	const errors = [];
-	const result = converted !== undefined ? [] : undefined;
-	const valueLength = value.length;
-	for (let i = 0; i < valueLength; i++) {
-		const itemPath = (path !== undefined ? path : "") + "[" + i + "]";
-		const itemResult = converted !== undefined ? {} : undefined;
-		const res = this.checkSchemaType(value[i], compiledArray, itemPath, value, itemResult);
-
-		if (res === true) {
-			if (converted !== undefined) {
-				result.push(itemResult.value !== undefined ? itemResult.value : value[i]);
-			}
-		} else {
-			this.handleResult(errors, itemPath, res, compiledArray.messages);
-		}
-	}
-
 	if (converted !== undefined) {
-		converted.value = result;
-	}
+		const result = [];
+		const valueLength = value.length;
+		for (let i = 0; i < valueLength; i++) {
+			const itemPath = (path !== undefined ? path : "") + "[" + i + "]";
+			const itemResult = {};
+			const res = this.checkSchemaType(value[i], compiledArray, itemPath, value, itemResult);
 
-	return errors.length === 0 ? true : errors;
+			if (res === true) {
+				result.push(itemResult.value !== undefined ? itemResult.value : value[i]);
+			} else {
+				this.handleResult(errors, itemPath, res, compiledArray.messages);
+			}
+		}
+		
+		if (errors.length > 0) {
+			return errors;
+		}
+
+		converted.value = result;
+
+		return true;
+	} else {
+		const valueLength = value.length;
+		for (let i = 0; i < valueLength; i++) {
+			const itemPath = (path !== undefined ? path : "") + "[" + i + "]";
+			const res = this.checkSchemaType(value[i], compiledArray, itemPath, value, undefined);
+
+			if (res !== true) {
+				this.handleResult(errors, itemPath, res);
+			}
+		}
+
+		return errors.length === 0 ? true : errors;
+	}
 };
 
 Validator.prototype.checkSchemaRule = function(value, compiledRule, path, parent, converted) {

--- a/test/rules/custom.spec.js
+++ b/test/rules/custom.spec.js
@@ -14,7 +14,7 @@ describe("Test checkCustom", () => {
 
 		expect(check(10, s)).toEqual(true);
 		expect(checker).toHaveBeenCalledTimes(1);
-		expect(checker).toHaveBeenCalledWith(10, s);
+		expect(checker).toHaveBeenCalledWith(10, s, undefined);
 	});
 
 	it("should handle returned errors", () => {
@@ -29,7 +29,7 @@ describe("Test checkCustom", () => {
 			expected: 3, 
 		});
 		expect(checker).toHaveBeenCalledTimes(1);
-		expect(checker).toHaveBeenCalledWith(10, s);
+		expect(checker).toHaveBeenCalledWith(10, s, undefined);
 	});
 
 });

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -1284,6 +1284,26 @@ describe("Test sanitizer", () => {
 		expect(converted.value).toEqual([ true, true, true, false, false, false]);
 	});
 
+	it("should sanitize array without conversion", () => {
+		const check = v.compile([{type: "array", items: { type: "string" } }]);
+		const converted = {};
+		check([ "string1", "string2" ], null, null, converted);
+		expect(converted.value).toEqual([ "string1", "string2" ]);
+	});
+
+	it("should not sanitize array with error", () => {
+		const check = v.compile([{type: "array", items: { type: "boolean", convert: true} }]);
+		const converted = {};
+		const res = check(["false", 123], null, null, converted);
+
+		expect(res).toBeInstanceOf(Array);
+		expect(res.length).toBe(1);
+		expect(res[0].type).toBe("boolean");
+		expect(res[0].field).toBe("[1]");
+
+		expect(converted.value).not.toBeDefined();
+	});
+
 	it("should sanitize date", () => {
 		const check = v.compile([{type: "date", convert: true}]);
 		const converted = {};

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -1291,6 +1291,20 @@ describe("Test sanitizer", () => {
 		expect(converted.value).toEqual([ "string1", "string2" ]);
 	});
 
+	it("should do nothing with string", () => {
+		const check = v.compile(["string"]);
+		const converted = {};
+		check("1", null, null, converted);
+		expect(converted.value).toEqual("1");
+	});
+
+	it("should do nothing with string in object", () => {
+		const check = v.compile({ name: "string"});
+		const converted = {};
+		check({name: "1"}, null, null, converted);
+		expect(converted.value).toEqual({name: "1"});
+	});
+
 	it("should not sanitize array with error", () => {
 		const check = v.compile([{type: "array", items: { type: "boolean", convert: true} }]);
 		const converted = {};


### PR DESCRIPTION
This proposes to add an optional `converted` parameter to the compiled checker function whose `value` property will be assigned the converted/sanitized value. It provides the framework for #15, upon which #18 could be implemented.

The performance is down somewhat because of the additional checks (~4.1mil->3.9 mil validations/sec on my box). This could be mitigated by having different code if the converted parameter is provided or not, but I have not done this (yet?).

I assume Codacy will complain again, but I dont know how to run the same checks locally. :(