### PR TITLE
Strict object validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * 13 built-in validators
 * custom validators
 * nested objects & array handling
+* strict object validation
 * multiple validators
 * customizable error messages
 * programmable error object
@@ -48,7 +49,7 @@ You can install it via [NPM](http://npmjs.org/).
 ```
 $ npm install fastest-validator --save
 ```
-or 
+or
 ```
 $ yarn add fastest-validator
 ```
@@ -56,7 +57,7 @@ $ yarn add fastest-validator
 ## Usage
 
 ### Simple method
-Call the `validate` method with the `object` and the `schema`. 
+Call the `validate` method with the `object` and the `schema`.
 > If performance is important, you won't use this method.
 
 ```js
@@ -76,7 +77,7 @@ console.log(v.validate({ id: 5, name: "John", status: true }, schema));
 console.log(v.validate({ id: 5, name: "Al", status: true }, schema));
 /* Returns an array with errors:
     [
-        { 
+        {
             type: 'stringMin',
             expected: 3,
             actual: 2,
@@ -111,7 +112,7 @@ console.log(check({ id: 5, name: "John", status: true }));
 console.log(check({ id: 2, name: "Adam" }));
 /* Returns an array with errors:
     [
-        { 
+        {
             type: 'required',
             field: 'status',
             message: 'The \'status\' field is required!'
@@ -155,6 +156,19 @@ v.validate({ name: "John" }, schema); // Valid
 v.validate({ age: 42 }, schema); // Fail
 ```
 
+# Strict validation
+Object properties which are not specified on the schema are ignored by default. If you set the `$$strict` option to `true` any aditional properties will result in an `strictObject` error.
+
+```js
+let schema = {
+    name: { type: "string" }, // required
+    $$strict: true // no additional properties allowed
+}
+
+v.validate({ name: "John" }, schema); // Valid
+v.validate({ name: "John", age: 42 }, schema); // Fail
+```
+
 # Multiple validators
 It is possible to define more validators for a field. In this case, only one validator needs to succeed for the field to be valid.
 
@@ -187,7 +201,7 @@ v.validate({ prop: "John" }, schema); // Valid
 ```
 
 ## `array`
-This is an `Array` validator. 
+This is an `Array` validator.
 
 **Simple example with strings:**
 ```js
@@ -226,7 +240,7 @@ let schema = {
     } }
 }
 
-v.validate({ 
+v.validate({
     users: [
         { id: 1, name: "John", status: true },
         { id: 2, name: "Jane", status: true },
@@ -259,7 +273,7 @@ v.validate({ roles: ["guest"] }, schema); // Fail
 
 
 ## `boolean`
-This is a `Boolean` validator. 
+This is a `Boolean` validator.
 
 ```js
 let schema = {
@@ -278,7 +292,7 @@ Property | Default  | Description
 
 
 ## `date`
-This is a `Date` validator. 
+This is a `Date` validator.
 
 ```js
 let schema = {
@@ -295,7 +309,7 @@ Property | Default  | Description
 `convert`  | `false`| if `true` and the type is not `Date`, try to convert with `new Date()`.
 
 ## `email`
-This is an e-mail address validator. 
+This is an e-mail address validator.
 
 ```js
 let schema = {
@@ -313,7 +327,7 @@ Property | Default  | Description
 `mode`   | `quick`  | Checker method. Can be `quick` or `precise`.
 
 ## `enum`
-This is an enum validator. 
+This is an enum validator.
 
 ```js
 let schema = {
@@ -332,7 +346,7 @@ Property | Default  | Description
 
 
 ## `forbidden`
-This validator returns an error if the property exists in the object. 
+This validator returns an error if the property exists in the object.
 
 ```js
 let schema = {
@@ -393,15 +407,15 @@ let schema = {
     } }
 }
 
-v.validate({ 
+v.validate({
     address: {
         country: "Italy",
         city: "Rome",
         zip: 12345
-    } 
+    }
 }, schema); // Valid
 
-v.validate({ 
+v.validate({
     address: {
         country: "Italy",
         city: "Rome"
@@ -409,6 +423,10 @@ v.validate({
 }, schema); // Fail ("The 'address.zip' field is required!")
 ```
 
+### Properties
+Property | Default  | Description
+-------- | -------- | -----------
+`strict`  | `false`| if `true` any properties which are not defined on the schema will throw an error.
 
 ## `string`
 This is a `String`.
@@ -440,7 +458,7 @@ Property | Default  | Description
 
 
 ## `url`
-This is an URL validator. 
+This is an URL validator.
 
 ```js
 let schema = {
@@ -502,9 +520,9 @@ let v = new Validator({
 
 const schema = {
 	name: { type: "string", min: 3, max: 255 },
-	weight: { 
-		type: "custom", 
-		minWeight: 10, 
+	weight: {
+		type: "custom",
+		minWeight: 10,
 		check(value, schema) {
 			return (value < schema.minWeight)
 				? this.makeError("weightMin", schema.minWeight, value)
@@ -518,12 +536,12 @@ console.log(v.validate({ name: "John", weight: 50 }, schema));
 
 console.log(v.validate({ name: "John", weight: 8 }, schema));
 /* Returns an array with errors:
-	[{ 
-		type: 'weightMin',                                       
-		expected: 10,                                            
-		actual: 8,                                               
-		field: 'weight',                                         
-		message: 'The weight must be greater than 10! Actual: 8' 
+	[{
+		type: 'weightMin',
+		expected: 10,
+		actual: 8,
+		field: 'weight',
+		message: 'The weight must be greater than 10! Actual: 8'
 	}]
 */
 ```
@@ -542,14 +560,14 @@ const v = new Validator({
 
 v.validate({ name: "John" }, { name: { type: "string", min: 6 }});
 /* Returns:
-[ 
-    { 
+[
+    {
         type: 'stringMin',
         expected: 6,
         actual: 4,
         field: 'name',
-        message: 'A(z) \'name\' mező túl rövid. Minimum: 6, Jelenleg: 4' 
-    } 
+        message: 'A(z) \'name\' mező túl rövid. Minimum: 6, Jelenleg: 4'
+    }
 ]
 */
 ```

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -24,7 +24,7 @@ module.exports = {
 	numberInteger: "The '{field}' field must be an integer!",
 	numberPositive: "The '{field}' field must be a positive number!",
 	numberNegative: "The '{field}' field must be a negative number!",
-	
+
 	array: "The '{field}' field must be an array!",
 	arrayEmpty: "The '{field}' field must not be an empty array!",
 	arrayMin: "The '{field}' field must contain at least {expected} items!",
@@ -42,10 +42,13 @@ module.exports = {
 	dateMax: "The '{field}' field must be less than or equal to {expected}!",
 
 	forbidden: "The '{field}' field is forbidden!",
-	
+
 	email: "The '{field}' field must be a valid e-mail!",
 
 	url: "The '{field}' field must be a valid URL!",
 
 	enumValue: "The '{field} field value '{expected}' does not match any of the allowed values!",
+
+	object: "The '{field}' must be an Object!",
+	objectStrict: "The object '{field}' contains invalid keys: {expected}!",
 };

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -50,5 +50,5 @@ module.exports = {
 	enumValue: "The '{field} field value '{expected}' does not match any of the allowed values!",
 
 	object: "The '{field}' must be an Object!",
-	objectStrict: "The object '{field}' contains invalid keys: {expected}!",
+	objectStrict: "The object '{field}' contains invalid keys: '{actual}'!",
 };

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -16,7 +16,7 @@ module.exports = function checkObject(value, schema) {
 			}
 		}
 		if (invalidProps.length !== 0) {
-			return this.makeError("objectStrict", invalidProps.join(", "));
+			return this.makeError("objectStrict", undefined, invalidProps.join(", "));
 		}
 	}
 

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -1,8 +1,23 @@
 "use strict";
 
-module.exports = function checkObject(value) {
+module.exports = function checkObject(value, schema) {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) {
 		return this.makeError("object");
+	}
+
+	if (schema.strict === true && schema.props) {
+		const allowedProps = Object.keys(schema.props);
+		const invalidProps = [];
+		const props = Object.keys(value);
+
+		for (let i = 0; i < props.length; i++) {
+			if (allowedProps.indexOf(props[i]) === -1) {
+				invalidProps.push(props[i]);
+			}
+		}
+		if (invalidProps.length !== 0) {
+			return this.makeError("objectStrict", invalidProps.join(", "));
+		}
 	}
 
 	return true;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -100,7 +100,7 @@ Validator.prototype.compile = function(schema) {
 		return function(value, path, parent) {
 			return self.checkSchemaType(value, rules, path, parent || null);
 		};
-	} 
+	}
 
 	const rule = this.compileSchemaObject(schema);
 	this.cache.clear();
@@ -113,6 +113,9 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 	if (schemaObject === null || typeof schemaObject !== "object" || Array.isArray(schemaObject)) {
 		throw new Error("Invalid schema!");
 	}
+
+	const strict = schemaObject.$$strict;
+	delete schemaObject.$$strict;
 
 	let compiledObject = this.cache.get(schemaObject);
 	if (compiledObject) {
@@ -132,6 +135,11 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 	sourceCode.push("let res;");
 	sourceCode.push("let propertyPath;");
 	sourceCode.push("const errors = [];");
+
+	if (strict === true) {
+		sourceCode.push("const givenProps = new Map(Object.keys(value).map(key => [key, true]));");
+	}
+
 	for (let i = 0; i < compiledObject.properties.length; i++) {
 		const property = compiledObject.properties[i];
 		const name = escapeEvalString(property.name);
@@ -145,6 +153,16 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 		}
 		sourceCode.push("if (res !== true) {");
 		sourceCode.push("\tthis.handleResult(errors, propertyPath, res);");
+		sourceCode.push("}");
+
+		if (strict === true) {
+			sourceCode.push(`givenProps.delete("${name}");`);
+		}
+	}
+
+	if (strict === true) {
+		sourceCode.push("if (givenProps.size !== 0) {");
+		sourceCode.push("\tthis.handleResult(errors, path || 'rootObject', this.makeError('objectStrict', undefined, [...givenProps.keys()].join(', ')));");
 		sourceCode.push("}");
 	}
 
@@ -254,7 +272,7 @@ Validator.prototype.checkSchemaType = function(value, compiledType, path, parent
 		}
 
 		return errors;
-	} 
+	}
 
 	return this.checkSchemaRule(value, compiledType, path, parent);
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -163,7 +163,7 @@ Validator.prototype.compileSchemaObject = function(schemaObject) {
 
 	if (strict === true) {
 		sourceCode.push("if (givenProps.size !== 0) {");
-		sourceCode.push("\tthis.handleResult(errors, path || 'rootObject', this.makeError('objectStrict', undefined, [...givenProps.keys()].join(', ')));");
+		sourceCode.push("\tthis.handleResult(errors, path || 'rootObject', this.makeError('objectStrict', undefined, [...givenProps.keys()].join(', ')), this.messages);");
 		sourceCode.push("}");
 	}
 

--- a/test/messages.spec.js
+++ b/test/messages.spec.js
@@ -39,6 +39,8 @@ describe("Test Messages", () => {
 		expect(msg.forbidden).toBeDefined();
 		expect(msg.email).toBeDefined();
 		expect(msg.url).toBeDefined();
+		expect(msg.object).toBeDefined();
+		expect(msg.objectStrict).toBeDefined();
 
 	});
 

--- a/test/rules/object.spec.js
+++ b/test/rules/object.spec.js
@@ -11,7 +11,9 @@ describe("Test checkObject", () => {
 	it("should check values", () => {
 		const s = { type: "object" };
 		const err = { type: "object" };
-		
+		const strict = { type: "object", strict: true, props: { a: "string" } };
+		const strictErr = {type: "objectStrict" };
+
 		expect(check(null, s)).toEqual(err);
 		expect(check(undefined, s)).toEqual(err);
 		expect(check(0, s)).toEqual(err);
@@ -21,5 +23,7 @@ describe("Test checkObject", () => {
 		expect(check(true, s)).toEqual(err);
 		expect(check([], s)).toEqual(err);
 		expect(check({}, s)).toEqual(true);
+		expect(check({a: "string"}, strict)).toEqual(true);
+		expect(check({a: "string", b: "string"}, strict)).toMatchObject(strictErr);
 	});
 });

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -332,7 +332,7 @@ describe("Test compile (integration test)", () => {
 
 		it("when schema is defined as an object, and custom path is specified, it should be forwarded to validators", () => {
 			// Note: as the item we validate always must be an object, there is no use
-			// of specifying a custom parent, like for the schema-as-array above. 
+			// of specifying a custom parent, like for the schema-as-array above.
 			// The parent is currently used in the validator code (only forwarded to the generated
 			// function that validates all properties) and there is no way to test it.
 			const v = new Validator();
@@ -665,19 +665,19 @@ describe("Test multiple rules with objects", () => {
 
 	let schema = {
 		list: [
-			{ 
+			{
 				type: "object",
 				props: {
 					name: {type: "string"},
 					age: {type: "number"},
-				} 
+				}
 			},
-			{ 
+			{
 				type: "object",
 				props: {
 					country: {type: "string"},
 					code: {type: "string"},
-				} 
+				}
 			}
 		]
 	};
@@ -746,19 +746,19 @@ describe("Test multiple rules with objects within array", () => {
 		list: {
 			type: "array",
 			items: [
-				{ 
+				{
 					type: "object",
 					props: {
 						name: {type: "string"},
 						age: {type: "number"},
-					} 
+					}
 				},
-				{ 
+				{
 					type: "object",
 					props: {
 						country: {type: "string"},
 						code: {type: "string"},
-					} 
+					}
 				}
 			]
 		}
@@ -885,9 +885,9 @@ describe("Test multiple rules with mixed types", () => {
 		expect(res).toBeInstanceOf(Array);
 		expect(res.length).toBe(2);
 		expect(res[0].type).toBe("string");
-		expect(res[0].field).toBe("value");		
+		expect(res[0].field).toBe("value");
 		expect(res[1].type).toBe("boolean");
-		expect(res[1].field).toBe("value");		
+		expect(res[1].field).toBe("value");
 	});
 
 	it("should give error if 'undefined'", () => {
@@ -897,9 +897,9 @@ describe("Test multiple rules with mixed types", () => {
 		expect(res).toBeInstanceOf(Array);
 		expect(res.length).toBe(2);
 		expect(res[0].type).toBe("required");
-		expect(res[0].field).toBe("value");		
+		expect(res[0].field).toBe("value");
 		expect(res[1].type).toBe("required");
-		expect(res[1].field).toBe("value");		
+		expect(res[1].field).toBe("value");
 	});
 
 });
@@ -909,13 +909,13 @@ describe("Test multiple rules with arrays", () => {
 
 	let schema = {
 		list: [
-			{ 
+			{
 				type: "array",
-				items: "string" 
+				items: "string"
 			},
-			{ 
+			{
 				type: "array",
-				items: "number" 
+				items: "number"
 			}
 		]
 	};
@@ -972,13 +972,13 @@ describe("Test multiple array in root", () => {
 	const v = new Validator();
 
 	let schema = [
-		{ 
+		{
 			type: "array",
-			items: "string" 
+			items: "string"
 		},
-		{ 
+		{
 			type: "array",
-			items: "number" 
+			items: "number"
 		}
 	];
 
@@ -1185,5 +1185,62 @@ describe("Test irregular object property names", () => {
 			try: "test",
 		}, schema);
 		expect(res).toBe(true);
+	});
+});
+
+describe("Test $$strict schema restriction on root-level", () => {
+	const v = new Validator();
+
+	let schema = {
+		name: "string",
+		$$strict: true
+	};
+
+	let check = v.compile(schema);
+
+	it("should give error if the object contains additional properties on the root-level", () => {
+		let obj = {
+			name: "test",
+			additionalProperty: "additional"
+		};
+
+		let res = check(obj);
+
+		expect(res).toBeInstanceOf(Array);
+		expect(res.length).toBe(1);
+		expect(res[0].field).toBe("rootObject");
+		expect(res[0].type).toBe("objectStrict");
+	});
+});
+
+describe("Test $$strict schema restriction on sub-level", () => {
+	const v = new Validator();
+
+	let schema = {
+		address: {
+			type: "object",
+			props: {
+				street: "string",
+				$$strict: true
+			}
+		}
+	};
+
+	let check = v.compile(schema);
+
+	it("should give error if the object contains additional properties on the sub-level", () => {
+		let obj = {
+			address: {
+				street: "test",
+				additionalProperty: "additional"
+			}
+		};
+
+		let res = check(obj);
+
+		expect(res).toBeInstanceOf(Array);
+		expect(res.length).toBe(1);
+		expect(res[0].field).toBe("address");
+		expect(res[0].type).toBe("objectStrict");
 	});
 });


### PR DESCRIPTION
I propose the addition of strict object validation:
Validate objects to only allow fields that are referenced in the props dictionary of an object.
```js
const schema = {
    obj: {
        type: "object",
        props: {
            a: "string"
        },
        strict: true
    }
};

console.log(v.validate({ obj: { a: "string" } }, schema));
// Returns: true

console.log(v.validate({ obj: { a: "string", b: "string" } }, schema));
/* Returns an array with errors:
[ { type: 'objectStrict',
    expected: 'b',
    actual: undefined,
    field: 'obj',
    message: 'The object \'obj\' contains invalid keys: b!' } ]
*/
```

Perhaps someone has a better name than "strict object validation" for this.

The performance impact with `npm run bench` is not measurable, but adding a separate "strictObject" validator is certainly possible if this is a problem.