### PR TITLE
Update type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare interface ValidationRuleObject {
     min?: number;
     max?: number;
     length?: number;
-    pattern?: RegExp;
+    pattern?: RegExp | string;
     contains?: string;
     enum?: any;
     values?: any[];


### PR DESCRIPTION
The pattern property supports Regex and strings but the types doesn't reflect this, so Typescript throws an error when using a schema with a string as pattern.