### PR TITLE
Add 'empty' property to ValidationRuleObject type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@
 declare interface ValidationRuleObject {
     type: string;
     optional?: boolean;
+	empty?: boolean;
     min?: number;
     max?: number;
     length?: number;


### PR DESCRIPTION
Type definition is missing 'empty' property on ValidationRuleObject