### PR TITLE
add types for 'mac' and 'luhn' validators, $$strict fix rework

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,23 @@ declare module 'fastest-validator' {
 	/**
 	 * Type of all possible Built-in validators names
 	 */
-	type ValidationRuleName = 'any' | 'array' | 'boolean' | 'date' | 'email' | 'enum' | 'forbidden' | 'function' | 'number' | 'object' | 'string' | 'url' | 'uuid' | 'custom';
+	type ValidationRuleName =
+		'any'
+		| 'array'
+		| 'boolean'
+		| 'date'
+		| 'email'
+		| 'enum'
+		| 'forbidden'
+		| 'function'
+		| 'luhn'
+		| 'mac'
+		| 'number'
+		| 'object'
+		| 'string'
+		| 'url'
+		| 'uuid'
+		| 'custom';
 
 	/**
 	 * Validation schema definition for "any" built-in validator
@@ -289,6 +305,28 @@ declare module 'fastest-validator' {
 	}
 
 	/**
+	 * Validation schema definition for "mac" built-in validator
+	 * @see https://github.com/icebob/fastest-validator#mac
+	 */
+	interface RuleMac extends RuleCustom {
+		/**
+		 * Name of built-in validator
+		 */
+		type: 'mac';
+	}
+
+	/**
+	 * Validation schema definition for "luhn" built-in validator
+	 * @see https://github.com/icebob/fastest-validator#luhn
+	 */
+	interface RuleLuhn extends RuleCustom {
+		/**
+		 * Name of built-in validator
+		 */
+		type: 'luhn';
+	}
+
+	/**
 	 * Validation schema definition for custom inline validator
 	 * @see https://github.com/icebob/fastest-validator#custom-validator
 	 */
@@ -479,6 +517,8 @@ declare module 'fastest-validator' {
 		| RuleEnum
 		| RuleForbidden
 		| RuleFunction
+		| RuleLuhn
+		| RuleMac
 		| RuleNumber
 		| RuleObject
 		| RuleString
@@ -598,6 +638,8 @@ declare module 'fastest-validator' {
 		RuleEnum,
 		RuleForbidden,
 		RuleFunction,
+		RuleLuhn,
+		RuleMac,
 		RuleNumber,
 		RuleObject,
 		RuleString,

--- a/index.d.ts
+++ b/index.d.ts
@@ -535,18 +535,17 @@ declare module 'fastest-validator' {
 	/**
 	 * Definition for validation schema based on validation rules
 	 */
-	type ValidationSchema = {
+	interface ValidationSchema {
 		/**
 		 * List of validation rules for each defined field
 		 */
-		[key: string]: ValidationRule
-	} & {
+		[key: string]: ValidationRule | boolean;
 		/**
 		 * Object properties which are not specified on the schema are ignored by default.
 		 * If you set the $$strict option to true any aditional properties will result in an strictObject error.
 		 * @default false
 		 */
-		$$strict?: boolean
+		$$strict?: boolean;
 	}
 
 	/**


### PR DESCRIPTION
I've updated types for build-in validators and rework my ValidationSchema fix. Now it's working correctly.