### PR TITLE
Making "{actual}" property available to custom string validation messages

### DIFF
--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -39,7 +39,7 @@ module.exports = function checkString(value, schema) {
 	}
 
 	if (schema.enum != null && schema.enum.indexOf(value) === -1) {
-		return this.makeError("stringEnum", schema.enum);
+		return this.makeError("stringEnum", schema.enum, value);
 	}
 
 	if (schema.numeric === true && !NUMERIC_PATTERN.test(value) ) {

--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -31,11 +31,11 @@ module.exports = function checkString(value, schema) {
 	if (schema.pattern != null) {
 		const pattern = typeof schema.pattern == "string" ? new RegExp(schema.pattern, schema.patternFlags) : schema.pattern;
 		if (!pattern.test(value))
-			return this.makeError("stringPattern", pattern );
+			return this.makeError("stringPattern", pattern, value);
 	}
 
 	if (schema.contains != null && value.indexOf(schema.contains) === -1) {
-		return this.makeError("stringContains", schema.contains);
+		return this.makeError("stringContains", schema.contains, value);
 	}
 
 	if (schema.enum != null && schema.enum.indexOf(value) === -1) {

--- a/test/rules/string.spec.js
+++ b/test/rules/string.spec.js
@@ -77,8 +77,8 @@ describe("Test checkString", () => {
 	it("check enum", () => {
 		const s = { type: "string", enum: ["male", "female"] };
 		
-		expect(check("", s)).toEqual({ type: "stringEnum", expected: ["male", "female"] });
-		expect(check("human", s)).toEqual({ type: "stringEnum", expected: ["male", "female"] });
+		expect(check("", s)).toEqual({ type: "stringEnum", expected: ["male", "female"], actual: "" });
+		expect(check("human", s)).toEqual({ type: "stringEnum", expected: ["male", "female"], actual: "human" });
 		expect(check("male", s)).toEqual(true);
 		expect(check("female", s)).toEqual(true);
 	});

--- a/test/rules/string.spec.js
+++ b/test/rules/string.spec.js
@@ -56,21 +56,21 @@ describe("Test checkString", () => {
 	it("check pattern", () => {
 		const s = { type: "string", pattern: /^[A-Z]+$/ };
 		
-		expect(check("John", s)).toEqual({ type: "stringPattern", expected: /^[A-Z]+$/ });
+		expect(check("John", s)).toEqual({ type: "stringPattern", expected: /^[A-Z]+$/, actual: "John" });
 		expect(check("JOHN", s)).toEqual(true);
 	});
 
 	it("check pattern with string", () => {
 		const s = { type: "string", pattern: "^[A-Z]+$", patternFlags: "g" };
 		
-		expect(check("John", s)).toEqual({ type: "stringPattern", expected: /^[A-Z]+$/g });
+		expect(check("John", s)).toEqual({ type: "stringPattern", expected: /^[A-Z]+$/g, actual: "John" });
 		expect(check("JOHN", s)).toEqual(true);
 	});
 
 	it("check contains", () => {
 		const s = { type: "string", contains: "bob" };
 		
-		expect(check("John", s)).toEqual({ type: "stringContains", expected: "bob" });
+		expect(check("John", s)).toEqual({ type: "stringContains", expected: "bob", actual: "John" });
 		expect(check("Icebob", s)).toEqual(true);
 	});
 


### PR DESCRIPTION
Using the {actual} placeholder on a custom message for `stringEnum` and a few other string validations wasn't working (the placeholder was replaced with an empty string) because the actual value was not being passed along to `this.makeError`.