### PR TITLE
Fix string with pattern where regular expression contains a double quote

### DIFF
--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -137,7 +137,7 @@ module.exports = function checkString({ schema, messages }, path, context) {
 
 		src.push(`
 			if (!${pattern.toString()}.test(value))
-				${this.makeError({ type: "stringPattern", expected: "\"" + pattern.toString() + "\"", actual: "origValue", messages })}
+				${this.makeError({ type: "stringPattern", expected: "\"" + pattern.toString().replace('"', "\\\"") + "\"", actual: "origValue", messages })}
 		`);
 	}
 

--- a/test/rules/string.spec.js
+++ b/test/rules/string.spec.js
@@ -50,8 +50,7 @@ describe("Test rule: string", () => {
 
 	it("check pattern", () => {
 		const check = v.compile({ $$root: true, type: "string", pattern: /^[A-Z]+$/ });
-		console.log(check("John"));
-		console.log([{ type: "stringPattern", expected: "/^[A-Z]+$/", actual: "John", message: "The '' field fails to match the required pattern." }]);
+
 		expect(check("John")).toEqual([{ type: "stringPattern", expected: "/^[A-Z]+$/", actual: "John", message: "The '' field fails to match the required pattern." }]);
 		expect(check("JOHN")).toEqual(true);
 	});
@@ -61,6 +60,13 @@ describe("Test rule: string", () => {
 
 		expect(check("John")).toEqual([{ type: "stringPattern", expected: "/^[A-Z]+$/g", actual: "John", message: "The '' field fails to match the required pattern." }]);
 		expect(check("JOHN")).toEqual(true);
+	});
+
+	it('check pattern with a quote', () => {
+		const check = v.compile({ $$root: true, type: 'string', pattern: /^[a-z0-9 .\-'?!":;\\/,_]+$/i });
+
+		expect(check('John^')).toEqual([{ field: undefined, type: 'stringPattern', expected: '/^[a-z0-9 .\-\'?!":;\\/,_]+$/i', actual: 'John^', message: 'The \'\' field fails to match the required pattern.' }]);
+		expect(check('JOHN')).toEqual(true);
 	});
 
 	it("check contains", () => {

--- a/test/rules/string.spec.js
+++ b/test/rules/string.spec.js
@@ -50,7 +50,8 @@ describe("Test rule: string", () => {
 
 	it("check pattern", () => {
 		const check = v.compile({ $$root: true, type: "string", pattern: /^[A-Z]+$/ });
-
+		console.log(check("John"));
+		console.log([{ type: "stringPattern", expected: "/^[A-Z]+$/", actual: "John", message: "The '' field fails to match the required pattern." }]);
 		expect(check("John")).toEqual([{ type: "stringPattern", expected: "/^[A-Z]+$/", actual: "John", message: "The '' field fails to match the required pattern." }]);
 		expect(check("JOHN")).toEqual(true);
 	});

--- a/test/typescript/rules/string.spec.ts
+++ b/test/typescript/rules/string.spec.ts
@@ -64,7 +64,14 @@ describe('TypeScript Definitions', () => {
             expect(check('JOHN')).toEqual(true);
         });
 
-        it('check contains', () => {
+		it('check pattern with a quote', () => {
+			const check = v.compile({ $$root: true, type: 'string', pattern: /^[a-z0-9 .\-'?!":;\\/,_]+$/i } as RuleString);
+
+			expect(check('John^')).toEqual([{ field: undefined, type: 'stringPattern', expected: '/^[a-z0-9 .\-\'?!":;\\/,_]+$/i', actual: 'John^', message: 'The \'\' field fails to match the required pattern.' }]);
+			expect(check('JOHN')).toEqual(true);
+		});
+
+		it('check contains', () => {
             const check = v.compile({ $$root: true, type: 'string', contains: 'bob' });
 
             expect(check('John')).toEqual([{ type: 'stringContains', expected: 'bob', actual: 'John', message: 'The \'\' field must contain the \'bob\' text.' }]);


### PR DESCRIPTION
For the string rule with pattern, if the regular expression contains a double quote an invalid token error occurs in the message field.  This is because the RegExp.toString does not escape the internal double quote and the construction of the message concatenates double quotes to this value.  

You can test this with sample regular expression /^[a-z0-9 .\-'?!":;\\/,_]+$/i

In this pull request, when constructing the message I replace the double quote with an escaped version, but due to the internal processing I have to also escape the escape character (\\\").

Jest reports 100% success for all tests plus the additional test I added.