### PR TITLE
Custom validation for built-in rules

### DIFF
--- a/examples/full.js
+++ b/examples/full.js
@@ -37,6 +37,7 @@ const schema = {
 	apikey: "forbidden",
 	uuidv4: { type: "uuid", version: 4 },
 	uuid: "uuid",
+	phone: { type: "string", length: 15, custom: v => v.startsWith("+") ? true : [{ type: "wrongPhoneFormat" }] },
 	action: "function",
 	created: "date",
 	now: { type: "date", convert: true }
@@ -86,6 +87,7 @@ const obj = {
 	apikey: null,
 	uuidv4: "10ba038e-48da-487b-96e8-8d3b99b6d18a",
 	uuid:   "10ba038e-48da-487b-96e8-8d3b99b6d18a",
+	phone: "+36-70-123-4567",
 	action: () => {},
 	created: new Date(),
 	now: Date.now()

--- a/index.d.ts
+++ b/index.d.ts
@@ -443,6 +443,14 @@ declare module 'fastest-validator' {
 		default?: any;
 
 		/**
+		 *
+		 * @param {{any}} value Value that should be validated
+		 * @param {ValidationRuleObject} schema Validation schema that describes current custom validator
+		 * @return {{true} | ValidationError[]} true if result is valid or array of validation error messages
+		 */
+		custom: (value: T, schema: ValidationRuleObject, path: string, parent?: object, context?: any) => true | ValidationError[];
+
+		/**
 		 * You can define any additional options for custom validators
 		 */
 		[key: string]: any;
@@ -772,7 +780,7 @@ declare module 'fastest-validator' {
 	 	* @param {string} name
 	 	* @param validationRule
 	 	*/
-		 alias(name: string, validationRule: ValidationRule): void;
+		alias(name: string, validationRule: ValidationRule): void;
 
 		/**
 		 * Build error message

--- a/index.d.ts
+++ b/index.d.ts
@@ -448,7 +448,7 @@ declare module 'fastest-validator' {
 		 * @param {ValidationRuleObject} schema Validation schema that describes current custom validator
 		 * @return {{true} | ValidationError[]} true if result is valid or array of validation error messages
 		 */
-		custom: (value: T, schema: ValidationRuleObject, path: string, parent?: object, context?: any) => true | ValidationError[];
+		custom?: (value: unknown, schema: ValidationRuleObject, path: string, parent?: object, context?: any) => true | ValidationError[];
 
 		/**
 		 * You can define any additional options for custom validators
@@ -799,7 +799,7 @@ declare module 'fastest-validator' {
 		 * @param {ValidationSchema | ValidationSchema[]} schema Validation schema definition that should be used for validation
 		 * @return {(object: object) => (true | ValidationError[])} function that can be used next for validation of current schema
 		 */
-		compile?(schema: ValidationSchema | ValidationSchema[]): (object: any) => true | ValidationError[];
+		compile(schema: ValidationSchema | ValidationSchema[]): (object: any) => true | ValidationError[];
 
 		/**
 		 * Native validation method to validate obj

--- a/index.d.ts
+++ b/index.d.ts
@@ -799,7 +799,7 @@ declare module 'fastest-validator' {
 		 * @param {ValidationSchema | ValidationSchema[]} schema Validation schema definition that should be used for validation
 		 * @return {(object: object) => (true | ValidationError[])} function that can be used next for validation of current schema
 		 */
-		compile(schema: ValidationSchema | ValidationSchema[]): (object: any) => true | ValidationError[];
+		compile?(schema: ValidationSchema | ValidationSchema[]): (object: any) => true | ValidationError[];
 
 		/**
 		 * Native validation method to validate obj

--- a/lib/rules/array.js
+++ b/lib/rules/array.js
@@ -2,7 +2,7 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path, context) {
+module.exports = function({ schema, messages, customValidation }, path, context) {
 	const src = [];
 
 	src.push(`
@@ -99,6 +99,7 @@ module.exports = function({ schema, messages }, path, context) {
 	}
 
 	src.push(`
+		${customValidation("value")}
 		return value;
 	`);
 

--- a/lib/rules/boolean.js
+++ b/lib/rules/boolean.js
@@ -2,7 +2,7 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	const src = [];
 	let sanitized = false;
 
@@ -36,6 +36,8 @@ module.exports = function({ schema, messages }, path) {
 	src.push(`
 		if (typeof value !== "boolean")
 			${this.makeError({ type: "boolean",  actual: "origValue", messages })}
+
+		${customValidation("value")}
 
 		return value;
 	`);

--- a/lib/rules/date.js
+++ b/lib/rules/date.js
@@ -2,7 +2,7 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	const src = [];
 	let sanitized = false;
 
@@ -22,6 +22,8 @@ module.exports = function({ schema, messages }, path) {
 	src.push(`
 		if (!(value instanceof Date) || isNaN(value.getTime()))
 			${this.makeError({ type: "date",  actual: "origValue", messages })}
+
+		${customValidation("value")}
 
 		return value;
 	`);

--- a/lib/rules/email.js
+++ b/lib/rules/email.js
@@ -5,7 +5,7 @@ const BASIC_PATTERN = /^\S+@\S+\.\S+$/;
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	const src = [];
 
 	const pattern = schema.mode == "precise" ? PRECISE_PATTERN : BASIC_PATTERN;
@@ -28,6 +28,8 @@ module.exports = function({ schema, messages }, path) {
 	src.push(`
 		if (!${pattern.toString()}.test(value))
 			${this.makeError({ type: "email",  actual: "value", messages })}
+
+		${customValidation("value")}
 
 		return value;
 	`);

--- a/lib/rules/enum.js
+++ b/lib/rules/enum.js
@@ -2,12 +2,14 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	const enumStr = JSON.stringify(schema.values || []);
 	return {
 		source: `
 			if (${enumStr}.indexOf(value) === -1)
 				${this.makeError({ type: "enumValue", expected: "\"" + schema.values.join(", ") + "\"", actual: "value", messages })}
+			
+			${customValidation("value")}
 
 			return value;
 		`

--- a/lib/rules/equal.js
+++ b/lib/rules/equal.js
@@ -2,7 +2,7 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	const src = [];
 
 	if (schema.field) {
@@ -34,6 +34,7 @@ module.exports = function({ schema, messages }, path) {
 	}
 
 	src.push(`
+		${customValidation("value")}
 		return value;
 	`);
 

--- a/lib/rules/forbidden.js
+++ b/lib/rules/forbidden.js
@@ -2,7 +2,7 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function checkForbidden({ schema, messages }, path) {
+module.exports = function checkForbidden({ schema, messages, customValidation }, path) {
 	const src = [];
 
 	src.push(`
@@ -22,6 +22,9 @@ module.exports = function checkForbidden({ schema, messages }, path) {
 
 	src.push(`
 		}
+
+		${customValidation("value")}
+
 		return value;
 	`);
 

--- a/lib/rules/function.js
+++ b/lib/rules/function.js
@@ -2,11 +2,13 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	return {
 		source: `
 			if (typeof value !== "function")
 				${this.makeError({ type: "function",  actual: "value", messages })}
+
+			${customValidation("value")}
 
 			return value;
 		`

--- a/lib/rules/luhn.js
+++ b/lib/rules/luhn.js
@@ -9,7 +9,7 @@
  *
  *	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	return {
 		source: `
 			if (typeof value !== "string") {
@@ -33,6 +33,8 @@ module.exports = function({ schema, messages }, path) {
 			if (!(sum % 10 === 0 && sum > 0)) {
 				${this.makeError({ type: "luhn",  actual: "value", messages })}
 			}
+
+			${customValidation("value")}
 
 			return value;
 		`

--- a/lib/rules/mac.js
+++ b/lib/rules/mac.js
@@ -4,7 +4,7 @@ const PATTERN = /^((([a-f0-9][a-f0-9]+[-]){5}|([a-f0-9][a-f0-9]+[:]){5})([a-f0-9
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	return {
 		source: `
 			if (typeof value !== "string") {
@@ -16,7 +16,7 @@ module.exports = function({ schema, messages }, path) {
 			if (!${PATTERN.toString()}.test(v)) {
 				${this.makeError({ type: "mac",  actual: "value", messages })}
 			}
-
+			${customValidation("value")}
 			return value;
 		`
 	};

--- a/lib/rules/multi.js
+++ b/lib/rules/multi.js
@@ -2,7 +2,7 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path, context) {
+module.exports = function({ schema, messages, customValidation }, path, context) {
 	const src = [];
 
 	src.push(`
@@ -33,7 +33,7 @@ module.exports = function({ schema, messages }, path, context) {
 		if (hasValid) {
 			errors.length = prevErrLen;
 		}
-
+		${customValidation("newVal")}
 		return newVal;
 	`);
 

--- a/lib/rules/number.js
+++ b/lib/rules/number.js
@@ -2,7 +2,7 @@
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	const src = [];
 
 	src.push(`
@@ -88,6 +88,7 @@ module.exports = function({ schema, messages }, path) {
 	}
 
 	src.push(`
+		${customValidation("value")}
 		return value;
 	`);
 

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -31,7 +31,7 @@ function escapeEvalString(str) {
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path, context) {
+module.exports = function({ schema, messages, customValidation }, path, context) {
 	const sourceCode = [];
 
 	sourceCode.push(`
@@ -101,6 +101,7 @@ module.exports = function({ schema, messages }, path, context) {
 		`);
 	} else {
 		sourceCode.push(`
+			${customValidation("value")}
 			return value;
 		`);
 	}

--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -7,7 +7,7 @@ const ALPHADASH_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function checkString({ schema, messages }, path, context) {
+module.exports = function checkString({ schema, messages, customValidation }, path, context) {
 	const src = [];
 	let sanitized = false;
 
@@ -191,6 +191,7 @@ module.exports = function checkString({ schema, messages }, path, context) {
 	}
 
 	src.push(`
+		${customValidation("value")}
 		return value;
 	`);
 

--- a/lib/rules/url.js
+++ b/lib/rules/url.js
@@ -6,7 +6,7 @@ const PATTERN = /^https?:\/\/\S+/;
 
 /**	Signature: function(value, field, parent, errors, context)
  */
-module.exports = function({ schema, messages }, path) {
+module.exports = function({ schema, messages, customValidation }, path) {
 	const src = [];
 	src.push(`
 		if (typeof value !== "string") {
@@ -17,6 +17,8 @@ module.exports = function({ schema, messages }, path) {
 		if (!${PATTERN.toString()}.test(value)) {
 			${this.makeError({ type: "url",  actual: "value", messages })}
 		}
+
+		${customValidation("value")}
 
 		return value;
 	`);

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -219,17 +219,17 @@ class Validator {
 			this.cache.set(rule.schema, rule);
 			rule.index = context.index;
 			context.rules[context.index] = rule;
-			if (typeof rule.schema.custom === "function"){
+			if (typeof rule.schema.custom === "function") {
 				context.customs[path] = { schema: rule.schema, messages: rule.messages };
-				rule.customValidation = (value) => `      
-				const rule = context.customs["${path}"];
-				const res = rule.schema.custom.call(this, ${value}, rule.schema, "${path}", parent, context);
+				rule.customValidation = value => `
+					const rule = context.customs["${path}"];
+					const res = rule.schema.custom.call(this, ${value}, rule.schema, "${path}", parent, context);
 					if (Array.isArray(res)) {
 						res.forEach(err => errors.push(Object.assign({ message: rule.messages[err.type], field }, err)));
 					}
 				`;
 			}
-		
+
 			context.index++;
 			const res = rule.ruleFunction.call(this, rule, path, context);
 			if (res.source) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -219,6 +219,17 @@ class Validator {
 			this.cache.set(rule.schema, rule);
 			rule.index = context.index;
 			context.rules[context.index] = rule;
+			if (typeof rule.schema.custom === "function"){
+				context.customs[path] = { schema: rule.schema, messages: rule.messages };
+				rule.customValidation = (value) => `      
+				const rule = context.customs["${path}"];
+				const res = rule.schema.custom.call(this, ${value}, rule.schema, "${path}", parent, context);
+					if (Array.isArray(res)) {
+						res.forEach(err => errors.push(Object.assign({ message: rule.messages[err.type], field }, err)));
+					}
+				`;
+			}
+		
 			context.index++;
 			const res = rule.ruleFunction.call(this, rule, path, context);
 			if (res.source) {
@@ -296,7 +307,8 @@ class Validator {
 		const rule = {
 			messages: Object.assign({}, this.messages, schema.messages),
 			schema: schema,
-			ruleFunction: ruleFunction
+			ruleFunction: ruleFunction,
+			customValidation: () => ""
 		};
 
 		return rule;

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -365,4 +365,44 @@ describe("Test aliases", () => {
 	});
 });
 
+describe("Test custom validation for built-in rules", () => {
+	const v = new Validator({
+		messages: {
+			evenNumber: "The '{field}' field must be an even number! Actual: {actual}"
+		}
+	});
+
+	let check;
+	const fn = jest.fn();
+
+
+	it("should compile without error", () => {
+		
+		check = v.compile({
+			num: {
+				type: "number",
+				min: 10,
+				max: 15,
+				integer: true,
+				custom(value){
+					fn(value);
+					if (value % 2 !== 0) return [{ type: "evenNumber", actual: value }];
+				}
+			}
+		});
+
+		expect(typeof check).toBe("function");
+	});
+
+	it("should work correctly with custom validator", () => {
+		const res = check({num: 12});
+		expect(res).toBe(true);
+		expect(fn).toBeCalledWith(12);
+
+		expect(check({num: 8})[0].type).toEqual("numberMin");
+		expect(check({num: 18})[0].type).toEqual("numberMax");
+		expect(check({num: 13})[0].type).toEqual("evenNumber");
+	});
+});
+
 


### PR DESCRIPTION
Related to #100 
Customizing built-in rules, without creating new rule. 
For example:
```js
check = v.compile({
   num: {
      type: "number",
      min: 10,
      max: 15,
      integer: true,
      custom (value, schema) {
         if (value % 2 !== 0) return [{ type: "evenNumber", actual: value }];
      }
   }
});
```