### PR TITLE
Type defs for custom validation, fixes.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -403,7 +403,7 @@ declare module 'fastest-validator' {
 	 * Validation schema definition for custom inline validator
 	 * @see https://github.com/icebob/fastest-validator#custom-validator
 	 */
-	interface RuleCustomInline extends RuleCustom {
+	interface RuleCustomInline<T = any> extends RuleCustom {
 		/**
 		 * Name of built-in validator
 		 */
@@ -411,7 +411,7 @@ declare module 'fastest-validator' {
 		/**
 		 * Custom checker function
 		 */
-		check: CheckerFunction;
+		check: CheckerFunction<T>;
 	}
 
 	/**
@@ -760,7 +760,7 @@ declare module 'fastest-validator' {
 		customs: { [ruleName: string]: { schema: RuleCustom, messages: MessagesType } }
 	}
 
-	type CheckerFunction = (value: unknown, schema: ValidationSchema, path: string, parent: object | null, context: Context) => true | ValidationError[];
+	type CheckerFunction<T = unknown> = (value: T, schema: ValidationSchema, path: string, parent: object | null, context: Context) => true | ValidationError[];
 
 	type CompilationFunction = (rule: CompilationRule, path: string, context: Context) => { sanitized?: boolean, source: string };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -791,7 +791,7 @@ declare module 'fastest-validator' {
 		 * @param {string} type
 		 * @param fn
 		 */
-		add(type: string, fn: any): void;
+		add(type: string, fn: CompilationFunction): void;
 
 		/**
 		 * Register a custom validation rule in validation object


### PR DESCRIPTION
Hello! I've improve some type definitions.

- CompilationRule, Context, CheckerFunction, CompilationFunction for custom rule definitions (directly in schema or by `add` method).
- RuleCustomInline upd: I think, generic isn't necesssary. Input type for validation - `unknown`.
- ValidationSchema fix: ability to use of root-level schema fields. For example - `min: 1`
- ValidationError fix: `type` changed to message name, `message` - string for custom message
- `compile`, `validate` methods fix: now it can be `any` type - not only object.