### PR TITLE
deep-extend: fix object type checking bug

### DIFF
--- a/lib/helpers/deep-extend.js
+++ b/lib/helpers/deep-extend.js
@@ -1,12 +1,13 @@
 "use strict";
 
-function isObject(v) {
-	return v != null && v.constructor.name === "Object";
+function isObjectHasKeys(v) {
+	if (typeof v !== "object" || v == null) return false;
+	return Object.keys(v).length > 0;
 }
 
 function deepExtend(destination, source, options = {}) {
 	for (let property in source) {
-		if (isObject(source[property]) && source[property] !== null) {
+		if (isObjectHasKeys(source[property])) {
 			destination[property] = destination[property] || {};
 			deepExtend(destination[property], source[property], options);
 		} else {

--- a/lib/helpers/deep-extend.js
+++ b/lib/helpers/deep-extend.js
@@ -1,12 +1,16 @@
 "use strict";
 
+function isObject(v) {
+	return v != null && v.constructor.name === "Object";
+}
+
 function deepExtend(destination, source, options = {}) {
 	for (let property in source) {
-		if (typeof source[property] === "object" && source[property] !== null) {
+		if (isObject(source[property]) && source[property] !== null) {
 			destination[property] = destination[property] || {};
 			deepExtend(destination[property], source[property], options);
 		} else {
-			if (options.skipIfExist === true && destination[property] !== undefined ) continue;
+			if (options.skipIfExist === true && destination[property] !== undefined) continue;
 			destination[property] = source[property];
 		}
 	}

--- a/test/helpers/deep-extend.spec.js
+++ b/test/helpers/deep-extend.spec.js
@@ -10,7 +10,7 @@ describe("deepExtend", () => {
 			},
 			d: true,
 			j: [],
-			k: [1,2]
+			k: [1,2],
 		}, {
 			a: {
 				b: 10,
@@ -21,7 +21,8 @@ describe("deepExtend", () => {
 				h: "H"
 			},
 			j: "some",
-			k: [5,6]
+			k: [5,6],
+			r: /s/
 		});
 		expect(result).toEqual({
 			a: {
@@ -35,7 +36,8 @@ describe("deepExtend", () => {
 				h: "H"
 			},
 			j: "some",
-			k: [5,6]
+			k: [5,6],
+			r: /s/
 		});
 	});
 });


### PR DESCRIPTION
`typeof o === "object"` doesn't always return expected result (e.g: with array, null, regexp, ....).
