### PR TITLE
improve type def for `CompilationFunction`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -786,7 +786,7 @@ declare module 'fastest-validator' {
 
 	type CheckerFunction<T = unknown> = (value: T, schema: ValidationSchema, path: string, parent: object | null, context: Context) => true | ValidationError[];
 
-	type CompilationFunction = (rule: CompilationRule, path: string, context: Context) => { sanitized?: boolean, source: string };
+	type CompilationFunction = (this: Validator, rule: CompilationRule, path: string, context: Context) => { sanitized?: boolean, source: string };
 
 	class Validator {
 		/**


### PR DESCRIPTION
type ```this``` as ```Validator```
so we can call it like ```this.makeError(...)```

without this change we will get ```'this' implicitly has type 'any' because it does not have a type annotation.ts(2683)``` if we call ```this.makeError``` inside ```CompilationFunction``` in TypeScript
