### PR TITLE
Added option to use generics with the `compile` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -715,11 +715,11 @@ declare module "fastest-validator" {
 		| ValidationRuleObject
 		| ValidationRuleObject[]
 		| ValidationRuleName;
-
+	
 	/**
 	 * Definition for validation schema based on validation rules
 	 */
-	interface ValidationSchema {
+	type ValidationSchema<T = any> = {
 		/**
 		 * Object properties which are not specified on the schema are ignored by default.
 		 * If you set the $$strict option to true any additional properties will result in an strictObject error.
@@ -733,12 +733,12 @@ declare module "fastest-validator" {
 		 * @default false
 		 */
 		$$root?: boolean;
-
+	} & {
 		/**
 		 * List of validation rules for each defined field
 		 */
-		[key: string]: ValidationRule | undefined | any;
-	}
+		[key in keyof T]: ValidationRule | undefined | any;
+	};
 
 	/**
 	 * Structure with description of validation error message
@@ -897,8 +897,8 @@ declare module "fastest-validator" {
 		 * @param {ValidationSchema | ValidationSchema[]} schema Validation schema definition that should be used for validation
 		 * @return {(value: any) => (true | ValidationError[])} function that can be used next for validation of current schema
 		 */
-		compile(
-			schema: ValidationSchema | ValidationSchema[]
+		compile<T = any>(
+		  schema: ValidationSchema<T> | ValidationSchema<T>[],
 		): (value: any) => true | ValidationError[];
 
 		/**


### PR DESCRIPTION
I've added support for generics on the `compile` method in order to take advantage of the Typescript validation when we are defining the schema as a param.

**Usage (before):**
```ts
type LoginRequest = {
  email: string;
  password: string;
};

const v = new Validator();

type CValidationSchema<T = any> = {
  $$strict?: boolean | 'remove';
  $$root?: boolean;
} & {
  [key in keyof T]: ValidationRule | undefined | any;
}

type CValidator<T> = (value: T) => true | ValidationError[];

const typedCompiler = <T>(schema: CValidationSchema<T>): CValidator<T> =>
  v.compile(schema);

const loginRequestValidator = typedCompiler<LoginRequest>({
  email: {type: 'email'},
  password: {type: 'string', empty: false, min: 6},
});
```

**Usage (after):**
```ts
type LoginRequest = {
  email: string;
  password: string;
};

const v = new Validator();

const loginRequestValidator = v.compile<LoginRequest>({
  email: {type: 'email'},
  password: {type: 'string', empty: false, min: 6},
});
```

I've set the `T` default value to `any` so the `compile` method can still be used without generics.

The most concerning part for me, regarding this commit, is that I've changed the `ValidationSchema` from **interface** to **type**. I've checked the code and I couldn't find any possible issue with it but I'm not totally sure about all the consequence. So please let me know if you find something.

If everything it's alright, I will continue with other PRs.