### PR TITLE
[Enhancement] Allow `empty = true` when using the `string` type with pattern

### DIFF
--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -136,9 +136,15 @@ module.exports = function checkString({ schema, messages }, path, context) {
 		if (typeof schema.pattern == "string")
 			pattern = new RegExp(schema.pattern, schema.patternFlags);
 
-		src.push(`
+		const patternValidator = `
 			if (!${pattern.toString()}.test(value))
 				${this.makeError({ type: "stringPattern", expected: "\"" + pattern.toString().replace('"', "\\\"") + "\"", actual: "origValue", messages })}
+		`;
+
+		src.push(`
+			if (${schema.empty} !== true || len !== 0) {
+				${patternValidator}
+			}
 		`);
 	}
 

--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -142,7 +142,9 @@ module.exports = function checkString({ schema, messages }, path, context) {
 		`;
 
 		src.push(`
-			if (${schema.empty} !== true || len !== 0) {
+			if (${schema.empty} !== false && len === 0) {
+				// Do nothing
+			} else {
 				${patternValidator}
 			}
 		`);

--- a/test/rules/string.spec.js
+++ b/test/rules/string.spec.js
@@ -27,6 +27,23 @@ describe("Test rule: string", () => {
 		expect(check("")).toEqual([{ type: "stringEmpty", actual: "", message: "The '' field must not be empty." }]);
 	});
 
+	it("check empty values (using pattern and empty=true)", () => {
+		const check = v.compile({ $$root: true, type: "string", pattern: "^fastest" });
+
+		expect(check("fastest-validator")).toEqual(true);
+		expect(check("")).toEqual(true);
+	});
+
+	it("check empty values (using pattern and empty=false)", () => {
+		const check = v.compile({ $$root: true, type: "string", pattern: "^fastest", empty: false });
+
+		expect(check("fastest-validator")).toEqual(true);
+		expect(check("")).toEqual([
+			{ type: "stringEmpty", actual: "", message: "The '' field must not be empty." },
+			{ type: "stringPattern", actual: "", "expected": "/^fastest/", message: "The '' field fails to match the required pattern." },
+		]);
+	});
+
 	it("check min length", () => {
 		const check = v.compile({ $$root: true, type: "string", min: 5 });
 

--- a/test/typescript/rules/string.spec.ts
+++ b/test/typescript/rules/string.spec.ts
@@ -23,11 +23,28 @@ describe('TypeScript Definitions', () => {
         });
 
         it('check empty values', () => {
-            const check = v.compile({ $$root: true, type: 'string', empty: false });
+            const check = v.compile({ $$root: true, type: 'string', empty: false } as RuleString);
 
             expect(check('abc')).toEqual(true);
             expect(check('')).toEqual([{ type: 'stringEmpty', actual: '', message: 'The \'\' field must not be empty.' }]);
         });
+
+		it("check empty values (using pattern and empty=true)", () => {
+			const check = v.compile({ $$root: true, type: "string", pattern: "^fastest" } as RuleString);
+
+			expect(check("fastest-validator")).toEqual(true);
+			expect(check("")).toEqual(true);
+		});
+
+		it("check empty values (using pattern and empty=false)", () => {
+			const check = v.compile({ $$root: true, type: "string", pattern: "^fastest", empty: false } as RuleString);
+
+			expect(check("fastest-validator")).toEqual(true);
+			expect(check("")).toEqual([
+				{ type: "stringEmpty", actual: "", message: "The '' field must not be empty." },
+				{ type: "stringPattern", actual: "", "expected": "/^fastest/", message: "The '' field fails to match the required pattern." },
+			]);
+		});
 
         it('check min length', () => {
             const check = v.compile({ $$root: true, type: 'string', min: 5 } as RuleString);


### PR DESCRIPTION
@icebob This PR will solve half of this issue: #116 

Usage (before):
```js
const schema = {
    pair: { type: "string", pattern: "^fastest", empty: true}
}

console.log(v.validate({ pair: "" }, schema)); // Fail (wrong pattern)
console.log(v.validate({ pair: "fastest-validator" }, schema)); // Valid
``` 

Usage (after):
```js
const schema = {
    pair: { type: "string", pattern: "^fastest", empty: true}
}

console.log(v.validate({ pair: "" }, schema)); // Valid
console.log(v.validate({ pair: "fastest-validator" }, schema)); // Valid
``` 

