### PR TITLE
Enhancement: empty property added to `email` rule 

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ v.validate({ email: "abc@gmail" }, schema); // Fail
 ### Properties
 Property | Default  | Description
 -------- | -------- | -----------
-`empty`  | `true`   | If `true`, the validator accepts an empty array `""`.
+`empty`  | `false`   | If `true`, the validator accepts an empty array `""`.
 `mode`   | `quick`  | Checker method. Can be `quick` or `precise`.
 `normalize`   | `false`  | Normalize the e-mail address (trim & lower-case). _It's a sanitizer, it will change the value in the original object._
 

--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ v.validate({ email: "abc@gmail" }, schema); // Fail
 ### Properties
 Property | Default  | Description
 -------- | -------- | -----------
+`empty`  | `true`   | If `true`, the validator accepts an empty array `""`.
 `mode`   | `quick`  | Checker method. Can be `quick` or `precise`.
 `normalize`   | `false`  | Normalize the e-mail address (trim & lower-case). _It's a sanitizer, it will change the value in the original object._
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,11 @@ declare module "fastest-validator" {
 		 */
 		type: "email";
 		/**
+		 * If true, the validator accepts an empty string ""
+		 * @default true
+		 */
+		empty?: boolean;
+		/**
 		 * Checker method. Can be quick or precise
 		 */
 		mode?: "quick" | "precise";

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -55,6 +55,7 @@ module.exports = {
 	function: "The '{field}' field must be a function.",
 
 	email: "The '{field}' field must be a valid e-mail.",
+	emailEmpty: "The '{field}' field must not be empty.",
 
 	luhn: "The '{field}' field must be a valid checksum luhn.",
 

--- a/lib/rules/email.js
+++ b/lib/rules/email.js
@@ -12,8 +12,20 @@ module.exports = function({ schema, messages }, path, context) {
 	let sanitized = false;
 
 	src.push(`
-		if (typeof value !== "string") {
+		var len = value.length;
+
+		if (len !== 0 && typeof value !== "string") {
 			${this.makeError({ type: "string",  actual: "value", messages })}
+			return value;
+		}
+	`);
+
+	src.push(`
+		if (len === 0) {
+			if (${schema.empty} === false) {
+				return ${this.makeError({ type: "emailEmpty", actual: "value", messages })}
+			}
+
 			return value;
 		}
 	`);

--- a/lib/rules/email.js
+++ b/lib/rules/email.js
@@ -12,15 +12,15 @@ module.exports = function({ schema, messages }, path, context) {
 	let sanitized = false;
 
 	src.push(`
-		var len = value.length;
-
-		if (len !== 0 && typeof value !== "string") {
+		if (typeof value !== "string") {
 			${this.makeError({ type: "string",  actual: "value", messages })}
 			return value;
 		}
 	`);
 
 	src.push(`
+		var len = value.length;
+
 		if (len === 0) {
 			if (${schema.empty} === false) {
 				return ${this.makeError({ type: "emailEmpty", actual: "value", messages })}

--- a/lib/rules/email.js
+++ b/lib/rules/email.js
@@ -18,17 +18,17 @@ module.exports = function({ schema, messages }, path, context) {
 		}
 	`);
 
-	src.push(`
-		var len = value.length;
-
-		if (len === 0) {
-			if (${!schema.empty}) {
+	if (!schema.empty) {
+		src.push(`
+			if (value.length === 0) {
 				return ${this.makeError({ type: "emailEmpty", actual: "value", messages })}
 			}
-
-			return value;
-		}
-	`);
+		`);
+	} else {
+		src.push(`
+			if (value.length === 0) return value;
+		`);
+	}
 
 	if (schema.normalize) {
 		sanitized = true;

--- a/lib/rules/email.js
+++ b/lib/rules/email.js
@@ -22,7 +22,7 @@ module.exports = function({ schema, messages }, path, context) {
 		var len = value.length;
 
 		if (len === 0) {
-			if (${schema.empty} === false) {
+			if (${!schema.empty}) {
 				return ${this.makeError({ type: "emailEmpty", actual: "value", messages })}
 			}
 

--- a/test/messages.spec.js
+++ b/test/messages.spec.js
@@ -42,6 +42,7 @@ describe("Test Messages", () => {
 		expect(msg.dateMax).toBeDefined();
 		expect(msg.forbidden).toBeDefined();
 		expect(msg.email).toBeDefined();
+		expect(msg.emailEmpty).toBeDefined();
 		expect(msg.url).toBeDefined();
 		expect(msg.enumValue).toBeDefined();
 		expect(msg.equalValue).toBeDefined();

--- a/test/rules/email.spec.js
+++ b/test/rules/email.spec.js
@@ -5,10 +5,10 @@ const v = new Validator();
 
 describe("Test rule: email", () => {
 	it("should check empty values", () => {
-		const check = v.compile({ $$root: true, type: "email", empty: false });
+		const check = v.compile({ $$root: true, type: "email", empty: true });
 
 		expect(check("john.doe@company.net")).toEqual(true);
-		expect(check("")).toEqual([{ type: "emailEmpty", actual: "", message: "The '' field must not be empty." }]);
+		expect(check("")).toEqual(true);
 	});
 
 	it("should check values", () => {
@@ -17,7 +17,7 @@ describe("Test rule: email", () => {
 
 		expect(check(0)).toEqual([{ type: "string", actual: 0, message }]);
 		expect(check(1)).toEqual([{ type: "string", actual: 1, message }]);
-		expect(check("")).toEqual(true);
+		expect(check("")).toEqual([{ type: "emailEmpty", actual: "", message: "The '' field must not be empty." }]);
 		expect(check("true")).toEqual([{ type: "email", actual: "true", message: "The '' field must be a valid e-mail." }]);
 		expect(check([])).toEqual([{ type: "string", actual: [], message }]);
 		expect(check({})).toEqual([{ type: "string", actual: {}, message }]);

--- a/test/typescript/rules/email.spec.ts
+++ b/test/typescript/rules/email.spec.ts
@@ -6,10 +6,10 @@ const v: ValidatorType = new Validator();
 
 describe("Test rule: email", () => {
 	it("should check empty values", () => {
-		const check = v.compile({ $$root: true, type: "email", empty: false } as RuleEmail);
+		const check = v.compile({ $$root: true, type: "email", empty: true } as RuleEmail);
 
 		expect(check("john.doe@company.net")).toEqual(true);
-		expect(check("")).toEqual([{ type: "emailEmpty", actual: "", message: "The '' field must not be empty." }]);
+		expect(check("")).toEqual(true);
 	});
 
 	it("should check values", () => {
@@ -18,7 +18,7 @@ describe("Test rule: email", () => {
 
 		expect(check(0)).toEqual([{ type: "string", actual: 0, message }]);
 		expect(check(1)).toEqual([{ type: "string", actual: 1, message }]);
-		expect(check("")).toEqual(true);
+		expect(check("")).toEqual([{ type: "emailEmpty", actual: "", message: "The '' field must not be empty." }]);
 		expect(check("true")).toEqual([{ type: "email", actual: "true", message: "The '' field must be a valid e-mail." }]);
 		expect(check([])).toEqual([{ type: "string", actual: [], message }]);
 		expect(check({})).toEqual([{ type: "string", actual: {}, message }]);

--- a/test/typescript/rules/email.spec.ts
+++ b/test/typescript/rules/email.spec.ts
@@ -1,18 +1,19 @@
-"use strict";
+/// <reference path="../../../index.d.ts" /> // here we make a reference to exists module definition
+import ValidatorType, {RuleEmail, RuleURL} from 'fastest-validator'; // here we importing type definition of default export
 
-const Validator = require("../../lib/validator");
-const v = new Validator();
+const Validator: typeof ValidatorType = require('../../../index'); // here we importing real Validator Constructor
+const v: ValidatorType = new Validator();
 
 describe("Test rule: email", () => {
 	it("should check empty values", () => {
-		const check = v.compile({ $$root: true, type: "email", empty: false });
+		const check = v.compile({ $$root: true, type: "email", empty: false } as RuleEmail);
 
 		expect(check("john.doe@company.net")).toEqual(true);
 		expect(check("")).toEqual([{ type: "emailEmpty", actual: "", message: "The '' field must not be empty." }]);
 	});
 
 	it("should check values", () => {
-		const check = v.compile({ $$root: true, type: "email" });
+		const check = v.compile({ $$root: true, type: "email" } as RuleEmail);
 		const message = "The '' field must be a string.";
 
 		expect(check(0)).toEqual([{ type: "string", actual: 0, message }]);
@@ -26,7 +27,7 @@ describe("Test rule: email", () => {
 	});
 
 	it("should check values with quick pattern", () => {
-		const check = v.compile({ $$root: true, type: "email" });
+		const check = v.compile({ $$root: true, type: "email" } as RuleEmail);
 		const message = "The '' field must be a valid e-mail.";
 
 		expect(check("abcdefg")).toEqual([{ type: "email", actual: "abcdefg", message }]);
@@ -43,7 +44,7 @@ describe("Test rule: email", () => {
 	});
 
 	it("should check values", () => {
-		const check = v.compile({ $$root: true, type: "email", mode: "precise" });
+		const check = v.compile({ $$root: true, type: "email", mode: "precise" } as RuleEmail);
 		const message = "The '' field must be a valid e-mail.";
 
 		expect(check("abcdefg")).toEqual([{ type: "email", actual: "abcdefg", message }]);
@@ -58,7 +59,7 @@ describe("Test rule: email", () => {
 	});
 
 	it("should not normalize", () => {
-		const check = v.compile({ email: { type: "email" } });
+		const check = v.compile({ email: { type: "email" } as RuleEmail });
 
 		const obj = { email: "John.Doe@Gmail.COM" };
 		expect(check(obj)).toEqual(true);
@@ -68,7 +69,7 @@ describe("Test rule: email", () => {
 	});
 
 	it("should normalize", () => {
-		const check = v.compile({ email: { type: "email", normalize: true } });
+		const check = v.compile({ email: { type: "email", normalize: true } as RuleEmail });
 
 		const obj = { email: " John.Doe@Gmail.COM   " };
 		expect(check(obj)).toEqual(true);


### PR DESCRIPTION
The `empty` property was added to the `email` rule (#116)

What was done:
- changes on `email.js`
- tests (including the Typescript ones)
- README.md was updated