### PR TITLE
Change ruleSchema type to be the object variant

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -840,7 +840,7 @@ declare module "fastest-validator" {
 
 	export type CheckerFunctionV1<T = unknown> = (
 		value: T,
-		ruleSchema: ValidationRule,
+		ruleSchema: ValidationRuleObject,
 		path: string,
 		parent: object | null,
 		context: Context
@@ -848,7 +848,7 @@ declare module "fastest-validator" {
 	export type CheckerFunctionV2<T = unknown> = (
 		value: T,
 		errors: CheckerFunctionError[],
-		ruleSchema: ValidationRule,
+		ruleSchema: ValidationRuleObject,
 		path: string,
 		parent: object | null,
 		context: Context


### PR DESCRIPTION
I believe there might have been some confusion in my comments in #156 .  I had made the comment

> As I dig in a bit more here, I am starting to think that the type here shouldn't be ValidationRule but should instead of ValidationRuleObject. It appears to be that the rule.schema passed to the custom validator always gets converted to an object and neither the string variant nor the array variant will ever get passed to the custom checker function.

I think that is the more appropriate type since it appears to me that even if the `ValidationRuleName` or `ValidationRuleObject[]` variants are passed in the validator schema, they will be cast to the `ValidationRuleObject` type when calling the custom function.

This PR changes the type in the custom validator signatures to be passed `ValidationRuleObject` rather than `ValidationRule`.