### PR TITLE
BREAKING CHANGE: update makeError method

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -163,30 +163,20 @@ class Validator {
 			}
 		}
 
-		const sourceCode = [
-			"var errors = [];",
-			"var field;",
-			"var parent = null;",
-		];
+		const sourceCode = [];
+		sourceCode.push(`
+			var errors = [];
+			var field = "";
+			var parent = null;
+		`);
 
 		const rule = this.getRuleFromSchema(schema);
 		sourceCode.push(this.compileRule(rule, context, null, "context.fn[%%INDEX%%](value, field, null, errors, context);", "value"));
 
-		sourceCode.push("if (errors.length) {");
 		sourceCode.push(`
-			return errors.map(err => {
-				if (err.message)
-					err.message = err.message
-						.replace(/\\{field\\}/g, err.field || "")
-						.replace(/\\{expected\\}/g, err.expected != null ? err.expected : "")
-						.replace(/\\{actual\\}/g, err.actual != null ? err.actual : "");
-
-				return err;
-			});
+			if (errors.length) return errors;
+			return true;
 		`);
-
-		sourceCode.push("}");
-		sourceCode.push("return true;");
 
 		const src = sourceCode.join("\n");
 
@@ -251,7 +241,7 @@ class Validator {
 				const fn = new Function("value", "field", "parent", "errors", "context", res.source);
 				context.fn[rule.index] = fn;
 				sourceCode.push(this.wrapRequiredCheckSourceCode(rule, innerSrc.replace(/%%INDEX%%/g, rule.index), resVar));
-				sourceCode.push(this.makeCustomValidator({vName: resVar, path: customPath, schema: rule.schema, context, messages: rule.messages, ruleIndex: rule.index}));
+				sourceCode.push(this.makeCustomValidator({ vName: resVar, path: customPath, schema: rule.schema, context, messages: rule.messages, ruleIndex: rule.index }));
 
 			} else {
 				sourceCode.push(this.wrapRequiredCheckSourceCode(rule));
@@ -353,12 +343,19 @@ class Validator {
 	 * @param {Object} opts.messages
 	 */
 	makeError({ type, field, expected, actual, messages }) {
+		let templateString = messages[type];
+
+		templateString = templateString.replace(/{field}/g, field !== undefined || "${field}");
+		templateString = templateString.replace(/{actual}/g, actual !== undefined ? "${" +  actual + "}" : "");
+		templateString = templateString.replace(/{expected}/g, expected !== undefined ? "${" + expected + "}" : "");
+				
 		const o = {
 			type: `"${type}"`,
-			message: `"${messages[type]}"`,
+			message: `\`${templateString}\``,
 		};
+
 		if (field) o.field = `"${field}"`;
-		else o.field = "field";
+		else o.field = "field === \"\" ? undefined : field" ;
 		if (expected != null) o.expected = expected;
 		if (actual != null) o.actual = actual;
 
@@ -392,11 +389,11 @@ class Validator {
                   
 			if (this.opts.useNewCustomCheckerFunction) {
 				return `
-               const ${ruleVName} = context.customs[${ruleIndex}];
+                	const ${ruleVName} = context.customs[${ruleIndex}];
 					const ${fnCustomErrorsVName} = [];
 					${vName} = ${ruleVName}.schema.${fnName}.call(this, ${vName}, ${fnCustomErrorsVName} , ${ruleVName}.schema, "${path}", parent, context);
 					if (Array.isArray(${fnCustomErrorsVName} )) {
-                  ${fnCustomErrorsVName} .forEach(err => errors.push(Object.assign({ message: ${ruleVName}.messages[err.type], field }, err)));
+                  		${fnCustomErrorsVName} .forEach(err => errors.push(Object.assign({ message: ${ruleVName}.messages[err.type], field }, err)));
 					}
 				`;
 			}
@@ -407,7 +404,7 @@ class Validator {
 				if (Array.isArray(res)) {
 					res.forEach(err => errors.push(Object.assign({ message: ${ruleVName}.messages[err.type], field }, err)));
 				}
-		`;
+			`;
 		}
 		return "";
 	}

--- a/test/rules/object.spec.js
+++ b/test/rules/object.spec.js
@@ -57,81 +57,81 @@ describe("Test rule: object", () => {
 			.toEqual([{ type: "required", field: "user.address.city", actual: undefined, message: "The 'user.address.city' field is required." }]);
 	});
 
-  it('should check min props', () => {
-      const check = v.compile({ $$root: true, type: 'object', props: {
-          optional_key_1: { type: 'string', optional: true },
-          optional_key_2: { type: 'number', optional: true },
-          optional_key_3: { type: 'boolean', optional: true },
-          optional_key_4: { type: 'array', optional: true },
-      }, minProps: 2 });
+	it("should check min props", () => {
+		const check = v.compile({ $$root: true, type: "object", props: {
+			optional_key_1: { type: "string", optional: true },
+			optional_key_2: { type: "number", optional: true },
+			optional_key_3: { type: "boolean", optional: true },
+			optional_key_4: { type: "array", optional: true },
+		}, minProps: 2 });
 
-      expect(check({})).toEqual([{ type: 'objectMinProps', actual: 0, expected: 2, message: "The object '' must contain at least 2 properties.", field: undefined }]);
-      expect(check({ optional_key_1: 'foobar', optional_key_2: 9 })).toEqual(true);
-      expect(check({ optional_key_1: 'foobar', optional_key_2: 9, optional_key_3: false })).toEqual(true);
+		expect(check({})).toEqual([{ type: "objectMinProps", actual: 0, expected: 2, message: "The object '' must contain at least 2 properties.", field: undefined }]);
+		expect(check({ optional_key_1: "foobar", optional_key_2: 9 })).toEqual(true);
+		expect(check({ optional_key_1: "foobar", optional_key_2: 9, optional_key_3: false })).toEqual(true);
 
-      const checkNested = v.compile({
-        key: { type: 'object',
-          props: {
-            nested: {
-              type: 'object',
-              props: {
-                optional_key_1: { type: 'string', optional: true },
-                optional_key_2: { type: 'number', optional: true },
-              },
-              minProps: 1
-            }
-          }
-        },
-      });
+		const checkNested = v.compile({
+			key: { type: "object",
+				props: {
+					nested: {
+						type: "object",
+						props: {
+							optional_key_1: { type: "string", optional: true },
+							optional_key_2: { type: "number", optional: true },
+						},
+						minProps: 1
+					}
+				}
+			},
+		});
 
-      expect(checkNested({ key: { nested: {} } })).toEqual([{ type: 'objectMinProps', actual: 0, expected: 1, message: "The object 'key.nested' must contain at least 1 properties.", field: 'key.nested' }]);
-      expect(checkNested({ key: { nested: { optional_key_1: 'foobar' } } })).toEqual(true);
-      expect(v.validate({}, {$$root: true, type: 'object', minProps: 0})).toEqual(true);
-  });
+		expect(checkNested({ key: { nested: {} } })).toEqual([{ type: "objectMinProps", actual: 0, expected: 1, message: "The object 'key.nested' must contain at least 1 properties.", field: "key.nested" }]);
+		expect(checkNested({ key: { nested: { optional_key_1: "foobar" } } })).toEqual(true);
+		expect(v.validate({}, {$$root: true, type: "object", minProps: 0})).toEqual(true);
+	});
 
-  it('should check max props', () => {
-      const check = v.compile({ $$root: true, type: 'object', props: {
-          optional_key_1: { type: 'string', optional: true },
-          optional_key_2: { type: 'number', optional: true },
-          optional_key_3: { type: 'boolean', optional: true },
-          optional_key_4: { type: 'array', optional: true },
-      }, maxProps: 2 });
+	it("should check max props", () => {
+		const check = v.compile({ $$root: true, type: "object", props: {
+			optional_key_1: { type: "string", optional: true },
+			optional_key_2: { type: "number", optional: true },
+			optional_key_3: { type: "boolean", optional: true },
+			optional_key_4: { type: "array", optional: true },
+		}, maxProps: 2 });
 
-      expect(check({ optional_key_1: 'foobar', optional_key_2: 9, optional_key_3: true })).toEqual([{ type: 'objectMaxProps', actual: 3, expected: 2, message: "The object '' must contain 2 properties at most.", field: undefined }]);
-      expect(check({ optional_key_1: 'foobar', optional_key_2: 9 })).toEqual(true);
-      expect(check({ optional_key_2: 9 })).toEqual(true);
-      expect(check({})).toEqual(true);
+		expect(check({ optional_key_1: "foobar", optional_key_2: 9, optional_key_3: true })).toEqual([{ type: "objectMaxProps", actual: 3, expected: 2, message: "The object '' must contain 2 properties at most.", field: undefined }]);
+		expect(check({ optional_key_1: "foobar", optional_key_2: 9 })).toEqual(true);
+		expect(check({ optional_key_2: 9 })).toEqual(true);
+		expect(check({})).toEqual(true);
 
-      const checkWithStrict = v.compile({ $$root: true, type: 'object', strict: 'remove', props: {
-          optional_key_1: { type: 'string' },
-          optional_key_2: { type: 'number' },
-      }, maxProps: 2 });
+		const checkWithStrict = v.compile({ $$root: true, type: "object", strict: "remove", props: {
+			optional_key_1: { type: "string" },
+			optional_key_2: { type: "number" },
+		}, maxProps: 2 });
 
-      expect(checkWithStrict({ optional_key_1: 'foobar', optional_key_2: 9, optional_key_3: true })).toEqual(true);
+		expect(checkWithStrict({ optional_key_1: "foobar", optional_key_2: 9, optional_key_3: true })).toEqual(true);
 
-      const checkNested = v.compile({
-        key: { type: 'object',
-          props: {
-            nested: {
-              type: 'object',
-              props: {
-                optional_key_1: { type: 'string', optional: true },
-                optional_key_2: { type: 'number', optional: true },
-              },
-              maxProps: 1
-            }
-          }
-        },
-      });
+		const checkNested = v.compile({
+			key: { type: "object",
+				props: {
+					nested: {
+						type: "object",
+						props: {
+							optional_key_1: { type: "string", optional: true },
+							optional_key_2: { type: "number", optional: true },
+						},
+						maxProps: 1
+					}
+				}
+			},
+		});
 
-      expect(checkNested({ key: { nested: {} } })).toEqual(true);
-      expect(checkNested({ key: { nested: { optional_key_1: 'foobar' } } })).toEqual(true);
-      expect(checkNested({ key: { nested: { optional_key_1: 'foobar', optional_key_3: 99 } } })).toEqual([{ type: 'objectMaxProps', actual: 2, expected: 1, message: "The object 'key.nested' must contain 1 properties at most.", field: 'key.nested' }]);
+		expect(checkNested({ key: { nested: {} } })).toEqual(true);
+		expect(checkNested({ key: { nested: { optional_key_1: "foobar" } } })).toEqual(true);
+		expect(checkNested({ key: { nested: { optional_key_1: "foobar", optional_key_3: 99 } } })).toEqual([{ type: "objectMaxProps", actual: 2, expected: 1, message: "The object 'key.nested' must contain 1 properties at most.", field: "key.nested" }]);
 
-      expect(v.validate({}, {$$root: true, type: 'object', maxProps: 0})).toEqual(true);
-      expect(v.validate({foo:'bar'}, {$$root: true, type: 'object', maxProps: 0})).toEqual([{actual: 1, field: undefined, message: "The object '' must contain 0 properties at most.", type: 'objectMaxProps', expected: 0}]);
-      expect(v.validate({foo:'bar'}, {$$root: true, type: 'object', maxProps: 0, strict: 'remove'})).toEqual([{actual: 1, field: undefined, message: "The object '' must contain 0 properties at most.", type: 'objectMaxProps', expected: 0}]);
-  });
+		expect(v.validate({}, {$$root: true, type: "object", maxProps: 0})).toEqual(true);
+		expect(v.validate({foo:"bar"}, {$$root: true, type: "object", maxProps: 0})).toEqual([{actual: 1, field: undefined, message: "The object '' must contain 0 properties at most.", type: "objectMaxProps", expected: 0}]);
+		expect(v.validate({foo:"bar"}, {$$root: true, type: "object", maxProps: 0, strict: "remove"})).toEqual([{actual: 1, field: undefined, message: "The object '' must contain 0 properties at most.", type: "objectMaxProps", expected: 0}]);
+	});
 
 
 	describe("Test sanitization", () => {


### PR DESCRIPTION
With these changes, now error messages can be generated without using slow regex replace, 4x faster in `validate with wrong obj` unit! (top: new , bottom: old)
![Screenshot from 2020-06-21 15-26-00](https://user-images.githubusercontent.com/47688578/85222971-68bee100-b3d4-11ea-86a6-01f2e87cf280.png)

But It will breaks current `CustomCheckerFunction` error message handler. 
Any comments?

I did not delete the failed tests