### PR TITLE
feat(uuid): support uuid v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,7 +1028,7 @@ v.validate({ uuid: "10ba038e-48da-487b-96e8-8d3b99b6d18a", version: 5 }, schema)
 ### Properties
 Property | Default  | Description
 -------- | -------- | -----------
-`version`  | `4`   | UUID version in range 1-5.
+`version`  | `4`   | UUID version in range 1-6.
 
 ## `objectID`
 You can validate BSON/MongoDB ObjectID's

--- a/lib/rules/uuid.js
+++ b/lib/rules/uuid.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-6][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**	Signature: function(value, field, parent, errors, context)
  */
@@ -34,6 +34,7 @@ module.exports = function({ schema, messages }, path) {
 		switch (version) {
 		case 1:
 		case 2:
+		case 6:
 			break;
 		case 3:
 		case 4:

--- a/test/rules/uuid.spec.js
+++ b/test/rules/uuid.spec.js
@@ -36,9 +36,11 @@ describe("Test rule: uuid", () => {
 		const check3 = v.compile({ $$root: true, type: "uuid", version: 3 });
 		const check4 = v.compile({ $$root: true, type: "uuid", version: 4 });
 		const check5 = v.compile({ $$root: true, type: "uuid", version: 5 });
+		const check6 = v.compile({ $$root: true, type: "uuid", version: 6 });
 		message = "The '' field must be a valid UUID version provided.";
 
 		expect(check1("9a7b330a-a736-51e5-af7f-feaf819cdc9f")).toEqual([{"actual": 5, "expected": 1, "type": "uuidVersion", message}]);
+		expect(check1("9a7b330a-a736-61e5-af7f-feaf819cdc9f")).toEqual([{"actual": 6, "expected": 1, "type": "uuidVersion", message}]);
 		expect(check1("9a7b330a-a736-51e5-af7f-feaf819cdc9f")).toEqual([{"actual": 5, "expected": 1, "type": "uuidVersion", message}]);
 		expect(check2("9a7b330a-a736-41e5-af7f-feaf819cdc9f")).toEqual([{"actual": 4, "expected": 2, "type": "uuidVersion", message}]);
 		expect(check3("9a7b330a-a736-41e5-af7f-feaf819cdc9f")).toEqual([{"actual": 4, "expected": 3, "type": "uuidVersion", message}]);
@@ -52,12 +54,14 @@ describe("Test rule: uuid", () => {
 		const check3 = v.compile({ $$root: true, type: "uuid", version: 3 });
 		const check4 = v.compile({ $$root: true, type: "uuid", version: 4 });
 		const check5 = v.compile({ $$root: true, type: "uuid", version: 5 });
+		const check6 = v.compile({ $$root: true, type: "uuid", version: 6 });
 
 		expect(check1("45745c60-7b1a-11e8-9c9c-2d42b21b1a3e")).toEqual(true);
 		expect(check2("9a7b330a-a736-21e5-af7f-feaf819cdc9f")).toEqual(true);
 		expect(check3("9125a8dc-52ee-365b-a5aa-81b0b3681cf6")).toEqual(true);
 		expect(check4("10ba038e-48da-487b-96e8-8d3b99b6d18a")).toEqual(true);
 		expect(check5("fdda765f-fc57-5604-a269-52a7df8164ec")).toEqual(true);
+		expect(check5("a9030619-8514-6970-e0f9-81b9ceb08a5f")).toEqual(true);
 
 	});
 
@@ -67,17 +71,20 @@ describe("Test rule: uuid", () => {
 		const check3 = v.compile({ $$root: true, type: "uuid", version: 3 });
 		const check4 = v.compile({ $$root: true, type: "uuid", version: 4 });
 		const check5 = v.compile({ $$root: true, type: "uuid", version: 5 });
+		const check6 = v.compile({ $$root: true, type: "uuid", version: 6 });
 
 		expect(check1("45745c60-7b1a-11e8-9c9c-2d42b21b1a3e")).toEqual(true);
 		expect(check2("9a7b330a-a736-21e5-af7f-feaf819cdc9f")).toEqual(true);
 		expect(check3("9125a8dc-52ee-365b-a5aa-81b0b3681cf6")).toEqual(true);
 		expect(check4("10ba038e-48da-487b-96e8-8d3b99b6d18a")).toEqual(true);
 		expect(check5("fdda765f-fc57-5604-a269-52a7df8164ec")).toEqual(true);
+		expect(check6("a9030619-8514-6970-e0f9-81b9ceb08a5f")).toEqual(true);
 		
 		expect(check1("45745C60-7B1A-11E8-9C9C-2D42B21B1A3E")).toEqual(true);
 		expect(check2("9A7B330A-A736-21E5-AF7F-FEAF819CDC9F")).toEqual(true);
 		expect(check3("9125A8DC-52EE-365B-A5AA-81B0B3681CF6")).toEqual(true);
 		expect(check4("10BA038E-48DA-487B-96E8-8D3B99B6D18A")).toEqual(true);
 		expect(check5("FDDA765F-FC57-5604-A269-52A7DF8164EC")).toEqual(true);
+		expect(check6("A9030619-8514-6970-E0F9-81B9CEB08A5F")).toEqual(true);
 	});
 });


### PR DESCRIPTION
Added support for uuid v6, which is a modified version from uuid v1 with lexicographic order for sorting.
Ref: https://www.npmjs.com/package/uuid-v6