### PR TITLE
[FIX] "any" rule should have source code

### DIFF
--- a/lib/rules/any.js
+++ b/lib/rules/any.js
@@ -3,5 +3,12 @@
 /**	Signature: function(value, field, parent, errors, context)
  */
 module.exports = function(/*{ schema, messages }, path, context*/) {
-	return {};
+	const src = [];
+	src.push(`
+		return value;
+	`);
+
+	return {
+		source: src.join("\n")
+	};
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -254,16 +254,11 @@ class Validator {
 
 			context.index++;
 			const res = rule.ruleFunction.call(this, rule, path, context);
-			if (res.source) {
-				res.source = res.source.replace(/%%INDEX%%/g, rule.index);
-				const fn = new Function("value", "field", "parent", "errors", "context", res.source);
-				context.fn[rule.index] = fn;
-				sourceCode.push(this.wrapRequiredCheckSourceCode(rule, innerSrc.replace(/%%INDEX%%/g, rule.index), context, resVar));
-				sourceCode.push(this.makeCustomValidator({vName: resVar, path: customPath, schema: rule.schema, context, messages: rule.messages, ruleIndex: rule.index}));
-
-			} else {
-				sourceCode.push(this.wrapRequiredCheckSourceCode(rule, "", context));
-			}
+			res.source = res.source.replace(/%%INDEX%%/g, rule.index);
+			const fn = new Function("value", "field", "parent", "errors", "context", res.source);
+			context.fn[rule.index] = fn;
+			sourceCode.push(this.wrapRequiredCheckSourceCode(rule, innerSrc.replace(/%%INDEX%%/g, rule.index), context, resVar));
+			sourceCode.push(this.makeCustomValidator({vName: resVar, path: customPath, schema: rule.schema, context, messages: rule.messages, ruleIndex: rule.index}));
 		}
 
 		return sourceCode.join("\n");

--- a/test/rules/any.spec.js
+++ b/test/rules/any.spec.js
@@ -2,6 +2,7 @@
 
 const Validator = require("../../lib/validator");
 const v = new Validator();
+const anyRule = require("../../lib/rules/any");
 
 describe("Test rule: any", () => {
 
@@ -31,5 +32,9 @@ describe("Test rule: any", () => {
 		expect(check("false")).toEqual(true);
 		expect(check([])).toEqual(true);
 		expect(check({})).toEqual(true);
+	});
+
+	it("should have source code", () => {
+		expect(anyRule().source).toBeTruthy();
 	});
 });


### PR DESCRIPTION
-> #184
It is better that all the rules have source code (include `any`). Because it's difficult to handle rules that don't have source code