### PR TITLE
allow converts objectID to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,7 +1108,7 @@ const schema = {
 ### Properties
 Property | Default  | Description
 -------- | -------- | -----------
-`convert`  | `false`   | If `true`, the validator converts ObjectID HexString representation to ObjectID `instance`
+`convert`  | `false`   | If `true`, the validator converts ObjectID HexString representation to ObjectID `instance`, otherwise validator return HexString
 
 
 # Custom validator

--- a/README.md
+++ b/README.md
@@ -1108,8 +1108,7 @@ const schema = {
 ### Properties
 Property | Default  | Description
 -------- | -------- | -----------
-`convert`  | `false`   | If `true`, the validator converts ObjectID HexString representation to ObjectID `instance`, otherwise validator return HexString
-
+`convert`  | `false`   | If `true`, the validator converts ObjectID HexString representation to ObjectID `instance`, if `hexString` the validator converts to HexString
 
 # Custom validator
 You can also create your custom validator.

--- a/index.d.ts
+++ b/index.d.ts
@@ -343,7 +343,7 @@ declare module "fastest-validator" {
 		/**
 		 * Convert HexStringObjectID to ObjectID
 		 */
-		convert?: boolean;
+		convert?: boolean | "hexString";
 	}
 
 	/**

--- a/lib/rules/objectID.js
+++ b/lib/rules/objectID.js
@@ -14,9 +14,11 @@ module.exports = function({ schema, messages, index }, path, context) {
 			${this.makeError({ type: "objectID", actual: "value", messages })}
 			return;
 		}
-
-		${schema.convert ? "return new ObjectID(value)" : "return value.toString();" } ;
 	`);
+
+	if (schema.convert === true) src.push("return new ObjectID(value)");
+	else if (schema.convert === "hexString") src.push("return value.toString()");
+	else src.push("return value");
 
 	return {
 		source: src.join("\n")

--- a/lib/rules/objectID.js
+++ b/lib/rules/objectID.js
@@ -15,7 +15,7 @@ module.exports = function({ schema, messages, index }, path, context) {
 			return;
 		}
 
-		${schema.convert ? "return new ObjectID(value)" : "return value;" } ;
+		${schema.convert ? "return new ObjectID(value)" : "return value.toString();" } ;
 	`);
 
 	return {

--- a/test/rules/objectID.spec.js
+++ b/test/rules/objectID.spec.js
@@ -12,12 +12,12 @@ describe("Test rule: objectID", () => {
 
 		expect(check({ id: "5f082780b00cc7401fb8"})).toEqual([{ type: "objectID", field: "id", actual: "5f082780b00cc7401fb8", message }]);
 		expect(check({ id: new ObjectID() })).toEqual(true);
-      
+
 		const o = { id: "5f082780b00cc7401fb8e8fc" };
 		expect(check(o)).toEqual(true);
 		expect(o.id).toBe("5f082780b00cc7401fb8e8fc");
 	});
-   
+
 	it("should convert hexString-objectID to ObjectID", () => {
 		const check = v.compile({ id: { type: "objectID", ObjectID, convert: true } });
 		const  oid = new ObjectID();
@@ -26,6 +26,17 @@ describe("Test rule: objectID", () => {
 		expect(check(o)).toEqual(true);
 		expect(o.id).toBeInstanceOf(ObjectID);
 		expect(o.id).toEqual(oid);
+	});
+
+	it("should convert hexString-objectID to hexString", () => {
+		const check = v.compile({ id: { type: "objectID", ObjectID, convert: "hexString" } });
+		const  oid = new ObjectID();
+		const  oidStr = oid.toHexString();
+		const o = { id: oid };
+
+		expect(check({ id: oidStr })).toEqual(true);
+		expect(check(o)).toEqual(true);
+		expect(o.id).toEqual(oidStr);
 	});
 
 	it("should catch hexString problems when convert: true", () => {


### PR DESCRIPTION
objectID pass between service.actions should be converted to string automatically, all params of `moleculer-db-adapter-mongoose`'s actions does not accept objectID instance. If dev want an objectID instance, he should call with `convert:true`