### PR TITLE
Delete `errors.push` returns as value

### DIFF
--- a/lib/rules/currency.js
+++ b/lib/rules/currency.js
@@ -1,27 +1,31 @@
 "use strict";
-const CURRENCY_REGEX = `(?=.*\\d)^(-?~1|~1-?)(([0-9]\\d{0,2}(~2\\d{3})*)|0)?(\\~3\\d{1,2})?$`;
+const CURRENCY_REGEX = "(?=.*\\d)^(-?~1|~1-?)(([0-9]\\d{0,2}(~2\\d{3})*)|0)?(\\~3\\d{1,2})?$";
 /**	Signature: function(value, field, parent, errors, context)
  */
 
 module.exports = function ({schema, messages}, path, context) {
 	const currencySymbol = schema.currencySymbol || null;
-	const thousandSeparator = schema.thousandSeparator || ',';
-	const decimalSeparator = schema.decimalSeparator || '.';
+	const thousandSeparator = schema.thousandSeparator || ",";
+	const decimalSeparator = schema.decimalSeparator || ".";
 	const customRegex = schema.customRegex;
 	let isCurrencySymbolMandatory = !schema.symbolOptional;
-	let finalRegex = CURRENCY_REGEX.replace(/~1/g, currencySymbol ? (`\\${currencySymbol}${(isCurrencySymbolMandatory ? '' : '?')}`) : '')
-		.replace('~2', thousandSeparator)
-		.replace('~3', decimalSeparator);
-	return {
-		source: `
-			if (!value.match(${customRegex || new RegExp(finalRegex)})){
-			return ${this.makeError({
-			type: "currency",
-			actual: "value",
-			messages
-		})}
-			}
+	let finalRegex = CURRENCY_REGEX.replace(/~1/g, currencySymbol ? (`\\${currencySymbol}${(isCurrencySymbolMandatory ? "" : "?")}`) : "")
+		.replace("~2", thousandSeparator)
+		.replace("~3", decimalSeparator);
+
+
+	const src = [];
+
+	src.push(`
+		if (!value.match(${customRegex || new RegExp(finalRegex)})) {
+			${this.makeError({ type: "currency", actual: "value", messages })}
 			return value;
-		`
+		}
+
+		return value;
+	`);
+
+	return {
+		source: src.join("\n")
 	};
 };

--- a/lib/rules/email.js
+++ b/lib/rules/email.js
@@ -21,7 +21,8 @@ module.exports = function({ schema, messages }, path, context) {
 	if (!schema.empty) {
 		src.push(`
 			if (value.length === 0) {
-				return ${this.makeError({ type: "emailEmpty", actual: "value", messages })}
+				${this.makeError({ type: "emailEmpty", actual: "value", messages })}
+				return;
 			}
 		`);
 	} else {

--- a/lib/rules/email.js
+++ b/lib/rules/email.js
@@ -22,7 +22,7 @@ module.exports = function({ schema, messages }, path, context) {
 		src.push(`
 			if (value.length === 0) {
 				${this.makeError({ type: "emailEmpty", actual: "value", messages })}
-				return;
+				return value;
 			}
 		`);
 	} else {

--- a/lib/rules/url.js
+++ b/lib/rules/url.js
@@ -19,7 +19,8 @@ module.exports = function ({ schema, messages }, path, context) {
 	if (!schema.empty) {
 		src.push(`
 			if (value.length === 0) {
-				return ${this.makeError({ type: "urlEmpty", actual: "value", messages })}
+				${this.makeError({ type: "urlEmpty", actual: "value", messages })}
+				return value;
 			}
 		`);
 	} else {


### PR DESCRIPTION
fixes #224 
Because `Array.prototype.push` returns array length. so we shouldn't do like this:
```js
`
return ${this.makeError({...})}
`
```

instead:

```js
`
${this.makeError({...})}
return;
`
```