### PR TITLE
[Docs] add a fastest-express-validator link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ console.log(check({ name: "Erf", age: 18 })); //true
 ### Supported frameworks
 - *Moleculer*: Natively supported
 - *Fastify*: By using [fastify-fv](https://github.com/erfanium/fastify-fv) 
+- *Express*: By using [fastest-express-validator](https://github.com/muturgan/fastest-express-validator) 
 
 
 # Optional, Required & Nullable fields


### PR DESCRIPTION
Hello!
I would be happy if you would let me add to readme a link to my express middleware based on fastest-validator.