### PR TITLE
feat: shorthand for regex

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -785,7 +785,8 @@ declare module "fastest-validator" {
 	export type ValidationRule =
 		| ValidationRuleObject
 		| ValidationRuleObject[]
-		| ValidationRuleName;
+		| ValidationRuleName
+	   | RegExp;
 
 	/**
 	 * Definition for validation schema based on validation rules

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -315,6 +315,11 @@ class Validator {
 				.every(rule => rule.schema.optional == true);
 			if (isOptional)
 				schema.optional = true;
+		} else if (schema instanceof RegExp) {
+			schema = {
+				type: "string",
+				pattern: schema
+			};
 		}
 
 		if (schema.$$type) {

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -251,6 +251,12 @@ describe("Test getRuleFromSchema method", () => {
 			expect(res2.schema).toEqual({ type: "array", optional: true, items: "string", min: 1 });
 		});
 
+		it("should convert RegExp", () => {
+			const regex = /(foo)/;
+			const res = v.getRuleFromSchema(regex);
+			expect(res.schema).toEqual({ type: "string", pattern: regex });
+		});
+
 	});
 
 	describe("Test objects shorthand rule ($$type)", () => {


### PR DESCRIPTION
Sample schema using this shorthand

```js
const schema = {
   a: /^(foo|bar)$/,
   b: /[a-z]/,
   c: /^[0-9]$/,
}
```