### PR TITLE
Fix mixed properties descriptions in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -387,11 +387,11 @@ export interface RuleString extends RuleCustom {
 	 */
 	enum?: string[];
 	/**
-	 * The value must be an alphabetic string
+	 * The value must be a numeric string
 	 */
 	numeric?: boolean;
 	/**
-	 * The value must be a numeric string
+	 * The value must be an alphabetic string
 	 */
 	alpha?: boolean;
 	/**


### PR DESCRIPTION
Descriptions for `numeric` and `alpha` are mixed, this PR aims to fix it