### PR TITLE
fix type of contains property in string validator options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -381,7 +381,7 @@ export interface RuleString extends RuleCustom {
 	/**
 	 * The value must contain this text
 	 */
-	contains?: string[];
+	contains?: string;
 	/**
 	 * The value must be an element of the enum array
 	 */


### PR DESCRIPTION
The typing for `contains` in the string validator options incorrectly specified a string array. The rule implementation only supports a single string.