### PR TITLE
add typing for currency rule

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ export type ValidationRuleName =
 	| "array"
 	| "boolean"
 	| "class"
+	| "currency"
 	| "custom"
 	| "date"
 	| "email"
@@ -101,6 +102,41 @@ export interface RuleClass<T = any> extends RuleCustom {
 	 * Checked Class
 	 */
 	instanceOf?: T;
+}
+
+/**
+ * Validation schema definition for "currency" built-in validator
+ * @see https://github.com/icebob/fastest-validator#currency
+ */
+export interface RuleCurrency extends RuleCustom {
+	/**
+	 * Name of built-in validator
+	 */
+	type: "currency";
+	/**
+	 * The currency symbol expected in string (as prefix)
+	 * @default null
+	 */
+	currencySymbol?: string;
+	/**
+	 * Toggle to make the currency symbol optional in string
+	 * @default false
+	 */
+	symbolOptional?: boolean;
+	/**
+	 * Thousand place separator character
+	 * @default ','
+	 */
+	thousandSeparator?: string;
+	/**
+	 * Decimal place character
+	 * @default '.'
+	 */
+	decimalSeparator?: string;
+	/**
+	 * Custom regular expression to validate currency strings
+	 */
+	customRegex?: RegExp | string;
 }
 
 /**
@@ -754,6 +790,7 @@ export type ValidationRuleObject =
 	| RuleArray
 	| RuleBoolean
 	| RuleClass
+	| RuleCurrency
 	| RuleDate
 	| RuleEmail
 	| RuleEqual


### PR DESCRIPTION
Add typing support for the `currency` validator and its options.