### PR TITLE
Add normalize method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1084,4 +1084,17 @@ export default class Validator {
 		schema: ValidationSchema;
 		ruleFunction: Function;
 	};
+
+	/**
+	 * Normalize a schema, type or short hand definition by expanding it to a full form. The 'normalized'
+	 * form is the equivalent schema with any short hands undone. This ensure that each rule; always includes
+	 * a 'type' key, arrays always have an 'items' key, 'multi' always have a 'rules' key and objects always
+	 * have their properties defined in a 'props' key
+	 *
+	 * @param { ValidationSchema | string | any } value The value to normalize
+	 * @return {ValidationRule | ValidationSchema } The normalized form of the given rule or schema
+	 */
+	normalize(
+		value: ValidationSchema | string | any
+	): ValidationRule | ValidationSchema
 }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -502,6 +502,72 @@ class Validator {
 		if (typeof fn !== "function") throw new Error("Plugin fn type must be function");
 		return fn(this);
 	}
+
+	/**
+	 * Normalize a schema, type or short hand definition by expanding it to a full form. The 'normalized'
+	 * form is the equivalent schema with any short hands undone. This ensure that each rule; always includes
+	 * a 'type' key, arrays always have an 'items' key, 'multi' always have a 'rules' key and objects always
+	 * have their properties defined in a 'props' key
+	 *
+	 * @param { * } value The value to normalize
+	 * @returns {Object} The normalized form of the given rule or schema
+	 */
+	normalize(value) {
+		let result;
+
+		if(typeof value === "string")
+			result = deepExtend({}, this.parseShortHand(value));
+		if(typeof result === "undefined")
+			result = deepExtend({}, value);
+		if(this.aliases[result.type])
+			result = deepExtend(result, this.normalize(this.aliases[result.type]), { skipIfExists: true});
+
+		result = deepExtend(result, this.defaults[result.type], { skipIfExist: true });
+
+		if(result.$$type) { // assume object type with other config
+			const type = result.$$type;
+			delete result.$$type;
+			const props = deepExtend({}, result);
+			result = this.normalize(type);
+			result.props = this.normalize(props);
+			return result;
+		}
+		if(Array.isArray(value)) {
+			result = {
+				type: "multi",
+				rules: value
+			};
+		}
+		if(result.type === "multi") {
+			result.rules = result.rules.map(r => this.normalize(r));
+			result.optional = result.rules.every(r => r.optional === true);
+			return result;
+		}
+		if(result.type === "array") {
+			result.items = this.normalize(result.items);
+			return result;
+		}
+		if(result.type === "object") {
+			if(result.props) {
+				for (const [k, v] of Object.entries(result.props)) {
+					result.props[k] = this.normalize(v);
+				}
+			}
+		}
+		if(typeof value === "object") {
+			if(value.type) {
+				const config = this.normalize(value.type);
+				deepExtend(result, config, { skipIfExists: true });
+			}
+			else{
+				for (const [k, v] of Object.entries(value)) {
+					result[k] = this.normalize(v);
+				}
+			}
+		}
+
+		return result;
+	}
 }
 
 module.exports = Validator;

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -695,3 +695,243 @@ describe("Test addMessage" , () => {
 	expect(v.messages.string).toBe("C");
 });
 
+describe("Test normalize", () => {
+	const v = new Validator({
+		defaults: {
+			object: {
+				strict: "remove"
+			}
+		},
+		aliases: {
+			age: "number|optional|integer|positive|min:0|max:99",
+			address: {
+				type: "object",
+				props: {
+					street: "string[]|max:2",
+					city: "string",
+					region: "string",
+					country: "string",
+					zip: {
+						type: "string",
+						pattern: /(^\d{5}$)|(^\d{5}-\d{4}$)/,
+					}
+				}
+			}
+		}
+	});
+	v.add("custom", () => "");
+	it("should not change original schema", () => {
+		const schema = {
+			a: "string",
+			b: {
+				$$type: "object",
+				c: "string[]"
+			}
+		};
+		v.normalize(schema);
+		expect(schema).toEqual(schema);
+	});
+	it("should normalize shorthands", () => {
+		expect(v.normalize("string[]|min:1|max:2|optional:false")).toEqual({
+			type: "array",
+			items: {
+				type: "string",
+			},
+			min: 1,
+			max: 2,
+			optional: false
+		});
+	});
+	it("should normalize with defaults included", () => {
+		const schema = {
+			type: "object",
+			props: {
+				a: "string"
+			}
+		};
+		expect(v.normalize(schema)).toEqual({
+			type: "object",
+			strict: "remove",
+			props: {
+				a: {
+					type: "string"
+				}
+			}
+		});
+	});
+	it("should normalize aliases", () => {
+		const schema = {
+			name: "string",
+			age: "age",
+			address: "address"
+		};
+		expect(v.normalize(schema)).toEqual({
+			name: {
+				type: "string"
+			},
+			age: {
+				type: "number",
+				positive: true,
+				integer: true,
+				min: 0,
+				max: 99,
+				optional: true
+			},
+			address: {
+				type: "object",
+				strict: "remove",
+				props: {
+					street: {
+						type: "array",
+						max: 2,
+						items: {
+							type: "string",
+						}
+					},
+					city: {
+						type: "string"
+					},
+					region: {
+						type: "string"
+					},
+					country: {
+						type: "string"
+					},
+					zip: {
+						type: "string",
+						pattern: /(^\d{5}$)|(^\d{5}-\d{4}$)/
+					}
+				}
+			}
+		});
+	});
+	it("should normalize with custom types", () => {
+		const schema = {
+			a: "string",
+			b: "custom",
+			c: {
+				type: "custom",
+				d: true,
+			}
+		};
+		expect(v.normalize(schema)).toEqual({
+			a: {
+				type: "string",
+			},
+			b: {
+				type: "custom"
+			},
+			c: {
+				type: "custom",
+				d: true
+			}
+		});
+	});
+	it("should normalize complex schema", () => {
+		const schema = {
+			a: {
+				$$type: "object|optional",
+				x: "number",
+				y: "number"
+			},
+			b: {
+				type: "object",
+				props: {
+					c: "string",
+					d: ["string", "boolean"],
+					e: {
+						type: "array",
+						items: "string"
+					},
+					f: ["string|optional", "boolean|optional"],
+					g: {
+						type: "array",
+						items: {
+							$$type: "object|optional",
+							h: "string",
+							i: "date[]"
+						}
+					},
+					j: "age"
+				}
+			}
+		};
+		expect(v.normalize(schema)).toEqual({
+			a: {
+				type: "object",
+				strict: "remove",
+				optional: true,
+				props: {
+					x: {
+						type: "number"
+					},
+					y: {
+						type: "number"
+					}
+				}
+			},
+			b: {
+				type: "object",
+				strict: "remove",
+				props: {
+					c: {
+						type: "string"
+					},
+					d: {
+						type: "multi",
+						optional: false,
+						rules: [{type: "string"}, {type: "boolean"}]
+					},
+					e: {
+						type: "array",
+						items: {
+							type: "string"
+						}
+					},
+					f: {
+						type: "multi",
+						optional: true,
+						rules: [
+							{
+								type: "string",
+								optional: true,
+							},
+							{
+								type: "boolean",
+								optional: true
+							}
+						]
+					},
+					g: {
+						type: "array",
+						items: {
+							type: "object",
+							optional: true,
+							strict: "remove",
+							props: {
+								h: {
+									type: "string"
+								},
+								i: {
+									type: "array",
+									items: {
+										type: "date"
+									},
+
+								}
+							},
+						}
+					},
+					j: {
+						type: "number",
+						optional: true,
+						integer: true,
+						positive: true,
+						min: 0,
+						max: 99
+					}
+				}
+			}
+		});
+	});
+});


### PR DESCRIPTION
This PR adds a `normalize` method to the Validator class. This method can take a schema, type, or string and resolve all shorthands and turn it into a 'normalized' form of a fastest-validator schema. This is useful for being able to inspect a schema and not have to worry about dealing with short hands, aliases, etc. 

For example: 
```
validator.normalize({ a: "string[]|optional" })
```
Will result in:
```
{
  a: {
    type: "array",
    optional: true,
    items: {
      type: "string"
    }
  }
}
```


Not a typescript guy so the ts definition of this method may not be super correct.

There's some duplication with the `getRuleFromSchema` method but I didn't want to make any changes there. Happy to revisit if required.