### PR TITLE
feat(rule:object): add entries to dynamic validate object key,value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -368,6 +368,13 @@ export interface RuleObject extends RuleCustom {
 	 * If set to a number, will throw if the number of props is greater than that number.
 	 */
 	maxProps?: number;
+	/**
+	 * validate object key and value
+	 */
+	entries?: {
+		key?: ValidationSchema
+		value?: ValidationSchema
+	}
 }
 
 export interface RuleObjectID extends RuleCustom {

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -41,10 +41,10 @@ module.exports = function ({ schema, messages }, path, context) {
 		}
 	`);
 
+	sourceCode.push("var parentObj = value;");
+	sourceCode.push("var parentField = field;");
 	const subSchema = schema.properties || schema.props;
 	if (subSchema) {
-		sourceCode.push("var parentObj = value;");
-		sourceCode.push("var parentField = field;");
 
 		const keys = Object.keys(subSchema);
 
@@ -86,7 +86,7 @@ module.exports = function ({ schema, messages }, path, context) {
 					}
 					if (invalidProps.length) {
 			`);
-			if (schema.strict == "remove") {
+			if (schema.strict === "remove") {
 				sourceCode.push(`
 						invalidProps.forEach(function(field) {
 							delete parentObj[field];
@@ -136,6 +136,87 @@ module.exports = function ({ schema, messages }, path, context) {
 			if (props.length > ${schema.maxProps}) {
 				${this.makeError({ type: "objectMaxProps", expected: schema.maxProps, actual: "props.length", messages })}
 			}
+		`);
+	}
+
+	if (schema.entries != null) {
+		sourceCode.push(`
+			// entries validate
+		`);
+		const objVal = subSchema ? "parentObj" : "value";
+		sourceCode.push(`
+			for (const objKey of Object.keys(${objVal})) {
+				const entriesErrors = [];
+				const entryErrors = [];
+				// override parent value due to undefined validate
+				const value = parentObj[objKey];
+				field = parentField ? parentField + \`["\${objKey}"]\` : objKey;
+				let tmpVar;
+`);
+		// todo: remove if #291 merged
+		sourceCode.push(`
+				const sizeErrors = errors.length;
+`);
+
+		[].concat(schema.entries).forEach(entry => {
+			// key should not sanitize but value can
+			if (entry.key) {
+				const rule = this.getRuleFromSchema(entry.key);
+				const innerSource = `
+				tmpVar = ${context.async ? "await " : ""}context.fn[%%INDEX%%](objKey, field, parentObj, entryErrors, context);
+			`;
+				sourceCode.push(this.compileRule(rule, context, null, innerSource, "tmpVar"));
+			}
+
+			if (entry.value) {
+				if (entry.key) {
+					sourceCode.push(`
+				if (
+					entryErrors.length === 0 &&
+					errors.length === sizeErrors // custom checker's errors
+				) {
+				`);
+				}
+				const rule = this.getRuleFromSchema(entry.value);
+				const innerSource = `
+					tmpVar = ${context.async ? "await " : ""}context.fn[%%INDEX%%](value, field, parentObj, entryErrors, context);
+				`;
+				sourceCode.push(this.compileRule(rule, context, null, innerSource, "tmpVar"));
+
+				if (entry.key) {
+					sourceCode.push(`
+				}
+				`);
+				}
+			}
+
+			sourceCode.push(`
+				if (
+					entryErrors.length === 0 &&
+					errors.length === sizeErrors // custom checker's errors
+				) {
+					continue;
+				} else {
+					Array.prototype.push.apply(entriesErrors, entryErrors.splice(0));
+				}
+			`);
+		});
+		sourceCode.push(`
+				if (
+					entriesErrors.length > 0 ||
+					errors.length !== sizeErrors // custom checker's errors
+				) {
+					Array.prototype.push.apply(errors, entriesErrors);
+					break; // field invalid. Stop checking
+				}
+		`);
+
+		sourceCode.push(`
+			}
+		`);
+
+		sourceCode.push(`
+			// entries validate - end
 		`);
 	}
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -547,6 +547,16 @@ class Validator {
 			if(result.props) {
 				Object.entries(result.props).forEach(([k,v]) => result.props[k] = this.normalize(v));
 			}
+			if (result.entries) {
+				[].concat(result.entries).forEach(prop => {
+					if (prop.key) {
+						prop.key = this.normalize(prop.key);
+					}
+					if (prop.value) {
+						prop.value = this.normalize(prop.value);
+					}
+				});
+			}
 		}
 		if(typeof value === "object") {
 			if(value.type) {

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -951,6 +951,35 @@ describe("Test normalize", () => {
 					},
 					j: "age"
 				}
+			},
+			c: {
+				type: "object",
+				entries: {
+					key: "string|min:1|max:2",
+				},
+				props: {
+					a: {
+						type: "object",
+						entries: {
+							value: "number[]"
+						}
+					},
+					b1: "number",
+					c2: {
+						type: "array",
+						items: {
+							type: "object",
+							props: {
+								d3: {
+									type: "object",
+									entries: {
+										value: "string[]"
+									}
+								}
+							}
+						}
+					}
+				}
 			}
 		};
 		expect(v.normalize(schema)).toEqual({
@@ -1028,6 +1057,55 @@ describe("Test normalize", () => {
 						max: 99
 					}
 				}
+			},
+			"c": {
+				"entries": {
+					"key": {
+						"max": 2,
+						"min": 1,
+						"type": "string"
+					}
+				},
+				"props": {
+					"a": {
+						"entries": {
+							"value": {
+								"items": {
+									"type": "number"
+								},
+								"type": "array"
+							}
+						},
+						"strict": "remove",
+						"type": "object"
+					},
+					"b1": {
+						"type": "number"
+					},
+					"c2": {
+						"items": {
+							"props": {
+								"d3": {
+									"entries": {
+										"value": {
+											"items": {
+												"type": "string"
+											},
+											"type": "array"
+										}
+									},
+									"strict": "remove",
+									"type": "object"
+								}
+							},
+							"strict": "remove",
+							"type": "object"
+						},
+						"type": "array"
+					}
+				},
+				"strict": "remove",
+				"type": "object"
 			}
 		});
 	});


### PR DESCRIPTION
add `entries` to object rule (same Object.entries) that will validate each object [key, value]
```js
{
  type: "object",
  entries: {
    key?: ValidationSchema,
    value?: ValidationSchema,
  }
}
```
===
maybe #276
need someone help me to update README because of my bad Engrisk
