### PR TITLE
Improve Types and IntelliSense for `compile` Function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -821,7 +821,7 @@ export type ValidationRule =
 /**
  * Definition for validation schema based on validation rules
  */
-export type ValidationSchema<T = any> = {
+export type ValidationSchema<T extends Record<string, ValidationRule> = any> = {
 	/**
 	 * Object properties which are not specified on the schema are ignored by default.
 	 * If you set the $$strict option to true any additional properties will result in an strictObject error.
@@ -845,7 +845,7 @@ export type ValidationSchema<T = any> = {
 	/**
 	 * List of validation rules for each defined field
 	 */
-	[key in keyof T]: ValidationRule | undefined | any;
+	[key in keyof T]: ValidationRule | undefined;
 };
 
 /**
@@ -1060,7 +1060,7 @@ export default class Validator {
 	 * @param {ValidationSchema | ValidationSchema[]} schema Validation schema definition that should be used for validation
 	 * @return {(value: any) => (true | ValidationError[])} function that can be used next for validation of current schema
 	 */
-	compile<T = any>(
+	compile<T extends Record<string, ValidationRule>>(
 		schema: ValidationSchema<T> | ValidationSchema<T>[]
 	): SyncCheckFunction | AsyncCheckFunction;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-
 export type ValidationRuleName =
 	| "any"
 	| "array"
@@ -843,11 +842,11 @@ export type ValidationSchema<T = any> = {
 	 */
 	$$root?: boolean;
 } & {
-		/**
-		 * List of validation rules for each defined field
-		 */
-		[key in keyof T]: ValidationRule | undefined | any;
-	};
+	/**
+	 * List of validation rules for each defined field
+	 */
+	[key in keyof T]: ValidationRule | undefined | any;
+};
 
 /**
  * Structure with description of validation error message
@@ -976,13 +975,15 @@ export interface CheckFunctionOptions {
 }
 
 export interface SyncCheckFunction {
-	(value: any, opts?: CheckFunctionOptions): true | ValidationError[]
-	async: false
+	(value: any, opts?: CheckFunctionOptions): true | ValidationError[];
+	async: false;
 }
 
 export interface AsyncCheckFunction {
-	(value: any, opts?: CheckFunctionOptions): Promise<true | ValidationError[]>
-	async: true
+	(value: any, opts?: CheckFunctionOptions): Promise<
+		true | ValidationError[]
+	>;
+	async: true;
 }
 
 export default class Validator {
@@ -1080,7 +1081,10 @@ export default class Validator {
 	 * @return {ValidationRule}
 	 */
 	getRuleFromSchema(
-		name: ValidationRuleName | ValidationRuleName[] | { [key: string]: unknown }
+		name:
+			| ValidationRuleName
+			| ValidationRuleName[]
+			| { [key: string]: unknown }
 	): {
 		messages: MessagesType;
 		schema: ValidationSchema;
@@ -1098,5 +1102,5 @@ export default class Validator {
 	 */
 	normalize(
 		value: ValidationSchema | string | any
-	): ValidationRule | ValidationSchema
+	): ValidationRule | ValidationSchema;
 }


### PR DESCRIPTION
In the past, it was impossible to get any meaningful/helpful TypeScript IntelliSense from the `compile` function while using it. This PR narrows the types so that TS can do this properly... but it still leaves things fairly lose in case there are users who don't want stricter types at the moment.

Some spacing/semicolon changes were added by my IDE. I can remove that commit if it's undesirable.