### PR TITLE
Add: haltOnFirstError option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ console.log("Second:", check({ id: 2, name: "Adam" }));
 ```
 [Try it on Repl.it](https://repl.it/@icebob/fastest-validator-fast)
 
+If you want to halt immediately after the first error use: `haltOnFirstError`
+```js
+const v = new Validator({haltOnFirstError: true});
+```
+
 ## Browser usage
 ```html
 <script src="https://unpkg.com/fastest-validator"></script>

--- a/examples/halt-on-first-error.js
+++ b/examples/halt-on-first-error.js
@@ -1,8 +1,8 @@
 "use strict";
 const Validator = require("../index");
 const v = new Validator({
-    haltOnFirstError: true,
-    debug: false,
+	haltOnFirstError: true,
+	debug: false,
 	useNewCustomCheckerFunction: true
 });
 
@@ -15,10 +15,10 @@ const schema = {
 			{ type: "object" }
 		]
 	}},
-    multi: [
+	multi: [
 		{ type: "string", min: 3, max: 255 },
 		{ type: "boolean" }
-	],   
+	],
 	sex: { type: "string", enum: ["male", "female"] },
 	sex2: { type: "enum", values: ["male", "female"] },
 	roles: { type: "array", items: { type: "string" }, enum: ["admin", "user"] },
@@ -70,7 +70,7 @@ const obj = {
 			corner: "top"
 		}
 	},
-    multi: "AA", // expect error
+	multi: "AA", // expect error
 	roles: [
 		"reader" // expect error
 	],

--- a/examples/halt-on-first-error.js
+++ b/examples/halt-on-first-error.js
@@ -1,0 +1,116 @@
+"use strict";
+const Validator = require("../index");
+const v = new Validator({
+    haltOnFirstError: true,
+    debug: false,
+	useNewCustomCheckerFunction: true
+});
+
+const schema = {
+	id: { type: "number", min: 8, max: 101 },
+	name: { type: "string", optional: false, min: 5, max: 128 },
+	settings: { type: "object", props: {
+		notify: [
+			{ type: "boolean" },
+			{ type: "object" }
+		]
+	}},
+    multi: [
+		{ type: "string", min: 3, max: 255 },
+		{ type: "boolean" }
+	],   
+	sex: { type: "string", enum: ["male", "female"] },
+	sex2: { type: "enum", values: ["male", "female"] },
+	roles: { type: "array", items: { type: "string" }, enum: ["admin", "user"] },
+	friends: { type: "array", items: { type: "number", positive: true }},
+	comments: { type: "array", items: { type: "object", props: {
+		user: { type: "number", positive: true, integer: true },
+		content: { type: "string" },
+		voters: { type: "array", optional: true, items: { type: "number" }}
+	} } },
+	multiarray: { type: "array", empty: false, items: {
+		type: "array", empty: true, items: {
+			type: "number"
+		}
+	}},
+	email: { type: "email", optional: true },
+	homepage: { type: "url", optional: true },
+	status: "boolean",
+	age: { type: "number", min: 18, max: 100, convert: true },
+	apikey: "forbidden",
+	uuidv4: { type: "uuid", version: 4 },
+	uuid: "uuid",
+	phone: { type: "string", length: 15, custom: (v, errors) => {
+		if (!v.startsWith("+"))
+			errors.push({ type: "phoneNumber", actual: v });
+		return v.replace(/[^\d+]/g, "");
+	} },
+	action: "function",
+	created: "date",
+	raw: { type: "class", instanceOf: Buffer, custom: v => v.toString("base64") },
+	now: { type: "date", convert: true },
+	state: {
+		type: "enum",
+		values: ["active", "inactive"],
+		defVal: "active",
+		default: (schema, field, parent, context) => {
+			return schema.defVal;
+		}
+	}
+};
+
+const obj = {
+	id: 5, // expect error min 8
+	name: "John", // expect error min len 5
+	sex: "N/A", // expect error
+	sex2: "invalid", // expect error
+	settings: {
+		//notify: true,
+		notify: {
+			corner: "top"
+		}
+	},
+    multi: "AA", // expect error
+	roles: [
+		"reader" // expect error
+	],
+
+	friends: [
+		5,
+		10,
+		2
+	],
+
+	comments: [
+		{ user: 1, content: "Cool!" },
+		{ user: 2, content: "Very fast!" },
+		{ user: 1, content: "", voters: [1] }
+	],
+
+	multiarray: [
+		[
+		],
+		[
+			5,
+			10,
+			//"a"
+		]
+	],
+
+	email: "john.doe@clipboard.space",
+	homepage: "http://google.com",
+	status: true,
+	age: "28",
+	apikey: null,
+	uuidv4: "10ba038e-48da-487b-96e8-8d3b99b6d18a",
+	uuid:   "10ba038e-48da-487b-96e8-8d3b99b6d18a",
+	phone: "+36-70-123-4567",
+	action: () => {},
+	created: new Date(),
+	now: Date.now(),
+	raw: Buffer.from([1,2,3])
+};
+
+const res = v.validate(obj, schema);
+
+console.log(res, obj);

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -65,6 +65,9 @@ module.exports = function ({ schema, messages }, path, context) {
 				${safePropName} = ${context.async ? "await " : ""}context.fn[%%INDEX%%](value, field, parentObj, errors, context);
 			`;
 			sourceCode.push(this.compileRule(rule, context, newPath, innerSource, safePropName));
+			if (this.opts.haltOnFirstError === true) {
+				sourceCode.push("if (errors.length) return parentObj;");
+			}			
 		}
 
 		// Strict handler

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -128,11 +128,11 @@ describe("Test add", () => {
 		}
 	});
 
-	const validFn = jest.fn(function({ schema, messages }, path, context) {
+	const validFn = jest.fn(function ({ schema, messages }, path, context) {
 		return {
 			source: `
 				if (value % 2 != 0)
-					${this.makeError({ type: "evenNumber",  actual: "value", messages })}
+					${this.makeError({ type: "evenNumber", actual: "value", messages })}
 				return value;
 			`
 		};
@@ -168,7 +168,7 @@ describe("Test add", () => {
 	});
 
 	it("should check the new rule", () => {
-		expect(check({ a: 5 })).toEqual([{"type": "evenNumber", "field": "a", "actual": 5, "message": "The 'a' field must be an even number! Actual: 5"}]);
+		expect(check({ a: 5 })).toEqual([{ "type": "evenNumber", "field": "a", "actual": 5, "message": "The 'a' field must be an even number! Actual: 5" }]);
 		expect(check({ a: 6 })).toEqual(true);
 	});
 
@@ -262,7 +262,7 @@ describe("Test getRuleFromSchema method", () => {
 			});
 
 			expect(res.schema).toEqual({
-				type: "object" ,
+				type: "object",
 				props: {
 					name: { type: "string" },
 					age: { type: "number" }
@@ -278,7 +278,7 @@ describe("Test getRuleFromSchema method", () => {
 			});
 
 			expect(res.schema).toEqual({
-				type: "object" ,
+				type: "object",
 				optional: true,
 				props: {
 					name: { type: "string" },
@@ -316,7 +316,7 @@ describe("Test compile (integration test)", () => {
 		let check = v.compile(schema);
 
 		it("should give back one errors", () => {
-			let res = check({id: 5, name: "John" });
+			let res = check({ id: 5, name: "John" });
 			expect(res).toBeInstanceOf(Array);
 
 			expect(res.length).toBe(1);
@@ -340,21 +340,21 @@ describe("Test compile (integration test)", () => {
 
 	});
 
-	describe("Test check generator with wrong obj and haltOnFirstError" , () => {
-		const v = new Validator({haltOnFirstError: true});
-
-		const schema = {
-			id: { type: "number" },
-			name: { type: "string", min: 5, optional: true },
-			password: { type: "forbidden" }
-		};
-
-		let check = v.compile(schema);
+	describe("Test check generator with wrong obj and haltOnFirstError", () => {
+		const v = new Validator({ haltOnFirstError: true });
 
 		it("should give back one errors", () => {
-			let res = check({id: "string", name: "John", password: "123456" });
-			expect(res).toBeInstanceOf(Array);
+			const schema = {
+				id: { type: "number" },
+				name: { type: "string", min: 5, uppercase: true },
+				password: { type: "forbidden" }
+			};
 
+			let check = v.compile(schema);
+			let obj = { id: "string", name: "John", password: "123456" };
+
+			let res = check(obj);
+			expect(res).toBeInstanceOf(Array);
 			expect(res.length).toBe(1);
 			expect(res[0]).toEqual({
 				type: "number",
@@ -362,9 +362,38 @@ describe("Test compile (integration test)", () => {
 				message: "The 'id' field must be a number.",
 				actual: "string",
 			});
+			expect(obj).toEqual({ id: "string", name: "John", password: "123456" });
+		});
+
+		it("should return true if no errors", () => {
+			const schema = {
+				id: { type: "number" },
+				name: { type: "string", min: 5, uppercase: true },
+				password: { type: "forbidden" }
+			};
+
+			let check = v.compile(schema);
+			let obj = { id: 5, name: "John Doe" };
+			let res = check(obj);
+			expect(res).toBe(true);
+			expect(obj).toEqual({ id: 5, name: "JOHN DOE" });
+		});
+
+		it("should return true if has valid in multi rule", () => {
+			const schema = {
+				status: [
+					{ type: "string", enums: ["active", "inactive"] },
+					{ type: "number", min: 0 }
+				]
+			};
+
+			let check = v.compile(schema);
+			expect(check({ status: "active" })).toBe(true);
+			expect(check({ status: 1 })).toBe(true);
+			expect(check({ status: false })).toEqual([{ "actual": false, "field": "status", "message": "The 'status' field must be a string.", "type": "string" }, { "actual": false, "field": "status", "message": "The 'status' field must be a number.", "type": "number" }]);
 		});
 	});
-	
+
 	/*
 	describe("Test check generator with custom path & parent", () => {
 		it("when schema is defined as an array, and custom path & parent are specified, they should be forwarded to validators", () => {
@@ -477,7 +506,7 @@ describe("Test custom validation v1", () => {
 				min: 10,
 				max: 15,
 				integer: true,
-				custom(value){
+				custom(value) {
 					if (value % 2 !== 0) return [{ type: "evenNumber", actual: value }];
 				}
 			}
@@ -494,20 +523,20 @@ describe("Test custom validation v1", () => {
 				min: 10,
 				max: 15,
 				integer: true,
-				custom(value){
+				custom(value) {
 					fn(this, value);
 					if (value % 2 !== 0) return [{ type: "evenNumber", actual: value }];
 				}
 			}
 		});
 
-		const res = check({num: 12});
+		const res = check({ num: 12 });
 		expect(res).toBe(true);
 		expect(fn).toBeCalledWith(v, 12);
 
-		expect(check({num: 8})[0].type).toEqual("numberMin");
-		expect(check({num: 18})[0].type).toEqual("numberMax");
-		expect(check({num: 13})[0].type).toEqual("evenNumber");
+		expect(check({ num: 8 })[0].type).toEqual("numberMin");
+		expect(check({ num: 18 })[0].type).toEqual("numberMax");
+		expect(check({ num: 13 })[0].type).toEqual("evenNumber");
 	});
 
 	it("should work with multiple custom validators", () => {
@@ -516,21 +545,21 @@ describe("Test custom validation v1", () => {
 		const check = v.compile({
 			a: {
 				type: "number",
-				custom(value){
+				custom(value) {
 					fn(value);
 					if (value % 2 !== 0) return [{ type: "evenNumber", actual: value }];
 				}
 			},
 			b: {
 				type: "number",
-				custom(value){
+				custom(value) {
 					fn(value);
 					if (value % 2 !== 0) return [{ type: "evenNumber", actual: value }];
 				}
 			}
 		});
 
-		const res = check({a: 12, b:10});
+		const res = check({ a: 12, b: 10 });
 		expect(res).toBe(true);
 		expect(fn).toBeCalledTimes(2);
 	});
@@ -556,8 +585,8 @@ describe("Test custom validation", () => {
 				min: 10,
 				max: 15,
 				integer: true,
-				custom(value, errors){
-					fn(this ,value, errors);
+				custom(value, errors) {
+					fn(this, value, errors);
 					if (value % 2 !== 0) errors.push({ type: "evenNumber", actual: value });
 					return value;
 				}
@@ -568,13 +597,13 @@ describe("Test custom validation", () => {
 	});
 
 	it("should work correctly with custom validator", () => {
-		const res = check({num: 12});
+		const res = check({ num: 12 });
 		expect(res).toBe(true);
 		expect(fn).toBeCalledWith(v, 12, []);
 
-		expect(check({num: 8})[0].type).toEqual("numberMin");
-		expect(check({num: 18})[0].type).toEqual("numberMax");
-		expect(check({num: 13})[0].type).toEqual("evenNumber");
+		expect(check({ num: 8 })[0].type).toEqual("numberMin");
+		expect(check({ num: 18 })[0].type).toEqual("numberMax");
+		expect(check({ num: 13 })[0].type).toEqual("evenNumber");
 	});
 
 	it("should call checker function after build-in rule", () => {
@@ -624,7 +653,7 @@ describe("Test default values", () => {
 		arr: {
 			type: "array",
 			items: "number",
-			default: [1,2,3]
+			default: [1, 2, 3]
 		},
 		obj: {
 			type: "object",
@@ -667,7 +696,7 @@ describe("Test default values", () => {
 			num: 123,
 			boolT: true,
 			boolF: false,
-			arr: [1,2,3],
+			arr: [1, 2, 3],
 			obj: {
 				id: 1,
 				name: "abc",
@@ -680,7 +709,7 @@ describe("Test default values", () => {
 		});
 
 		expect(fn).toBeCalledTimes(1);
-		expect(fn).toBeCalledWith(schema.par.properties.name, "par.name", obj, expect.any(Object) );
+		expect(fn).toBeCalledWith(schema.par.properties.name, "par.name", obj, expect.any(Object));
 	});
 });
 
@@ -801,7 +830,7 @@ describe("Test plugins", () => {
 	});
 });
 
-describe("Test addMessage" , () => {
+describe("Test addMessage", () => {
 	const v = new Validator();
 	v.addMessage("string", "C");
 	expect(v.messages.string).toBe("C");
@@ -1002,7 +1031,7 @@ describe("Test normalize", () => {
 					d: {
 						type: "multi",
 						optional: false,
-						rules: [{type: "string"}, {type: "boolean"}]
+						rules: [{ type: "string" }, { type: "boolean" }]
 					},
 					e: {
 						type: "array",

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -340,6 +340,31 @@ describe("Test compile (integration test)", () => {
 
 	});
 
+	describe("Test check generator with wrong obj and haltOnFirstError" , () => {
+		const v = new Validator({haltOnFirstError: true});
+
+		const schema = {
+			id: { type: "number" },
+			name: { type: "string", min: 5, optional: true },
+			password: { type: "forbidden" }
+		};
+
+		let check = v.compile(schema);
+
+		it("should give back one errors", () => {
+			let res = check({id: "string", name: "John", password: "123456" });
+			expect(res).toBeInstanceOf(Array);
+
+			expect(res.length).toBe(1);
+			expect(res[0]).toEqual({
+				type: "number",
+				field: "id",
+				message: "The 'id' field must be a number.",
+				actual: "string",
+			});
+		});
+	});
+	
 	/*
 	describe("Test check generator with custom path & parent", () => {
 		it("when schema is defined as an array, and custom path & parent are specified, they should be forwarded to validators", () => {


### PR DESCRIPTION
### Description
Setting `haltOnFirstError: true` will halt checks and return immediately after the first error, if any.
Closes #299 

#### Usage
```js
const v = new Validator({haltOnFirstError: true});
```
 
### Checks

- [x] Add tests
- [x] Add examples