### PR TITLE
allow to add metas in the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1547,7 +1547,7 @@ Name                | Default text
 `dateMin`	| The '{field}' field must be greater than or equal to {expected}.
 `dateMax`	| The '{field}' field must be less than or equal to {expected}.
 `forbidden`	| The '{field}' field is forbidden.
-‍‍`email` | The '{field}' field must be a valid e-mail.
+`email` | The '{field}' field must be a valid e-mail.
 `emailEmpty` | The '{field}' field must not be empty.
 `emailMin` | The '{field}' field length must be greater than or equal to {expected} characters long.
 `emailMax` | The '{field}' field length must be less than or equal to {expected} characters long.
@@ -1570,6 +1570,20 @@ Name        | Description
 `field`     | The field name
 `expected`  | The expected value
 `actual`    | The actual value
+
+# Pass custom metas
+In some case, you will need to do something with the validation schema . 
+Like reusing the validator to pass custom settings, you can use properties starting with `$$`
+
+````typescript
+const check = v.compile({
+    $$name: 'Person',
+    $$description: 'write a description about this schema',
+    firstName: { type: "string" },
+    lastName: { type: "string" },
+    birthDate: { type: "date" }    
+});
+````
 
 # Development
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -837,9 +837,9 @@ export type ValidationRule =
 	| ValidationRuleName;
 
 /**
- * Definition for validation schema based on validation rules
+ *
  */
-export type ValidationSchema<T = any> = {
+export interface ValidationSchemaMetaKeys {
 	/**
 	 * Object properties which are not specified on the schema are ignored by default.
 	 * If you set the $$strict option to true any additional properties will result in an strictObject error.
@@ -859,12 +859,18 @@ export type ValidationSchema<T = any> = {
 	 * @default false
 	 */
 	$$root?: boolean;
-} & {
-		/**
-		 * List of validation rules for each defined field
-		 */
-		[key in keyof T]: ValidationRule | undefined | any;
-	};
+}
+
+/**
+ * Definition for validation schema based on validation rules
+ */
+export type ValidationSchema<T = any> = ValidationSchemaMetaKeys & {
+	/**
+	 * List of validation rules for each defined field
+	 */
+	[key in keyof T]: ValidationRule | undefined | any;
+}
+
 
 /**
  * Structure with description of validation error message

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -46,7 +46,7 @@ module.exports = function ({ schema, messages }, path, context) {
 		sourceCode.push("var parentObj = value;");
 		sourceCode.push("var parentField = field;");
 
-		const keys = Object.keys(subSchema);
+		const keys = Object.keys(subSchema).filter(key => !this.isMetaKey(key));
 
 		for (let i = 0; i < keys.length; i++) {
 			const property = keys[i];
@@ -58,7 +58,7 @@ module.exports = function ({ schema, messages }, path, context) {
 
 			const labelName = subSchema[property].label;
 			const label = labelName ? `'${escapeEvalString(labelName)}'` : undefined;
-			
+
 			sourceCode.push(`\n// Field: ${escapeEvalString(newPath)}`);
 			sourceCode.push(`field = parentField ? parentField + "${safeSubName}" : "${name}";`);
 			sourceCode.push(`value = ${safePropName};`);
@@ -70,7 +70,7 @@ module.exports = function ({ schema, messages }, path, context) {
 			sourceCode.push(this.compileRule(rule, context, newPath, innerSource, safePropName));
 			if (this.opts.haltOnFirstError === true) {
 				sourceCode.push("if (errors.length) return parentObj;");
-			}			
+			}
 		}
 
 		// Strict handler

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -204,7 +204,13 @@ class Validator {
 					properties: prevSchema
 				};
 
-				delete prevSchema.$$strict;
+				Object.keys(prevSchema).forEach(key => {
+					if(!key.startsWith("$$")) {
+						return;
+					}
+
+					delete prevSchema[key];
+				});
 			}
 		}
 
@@ -316,14 +322,15 @@ class Validator {
 	getRuleFromSchema(schema) {
 		schema = this.resolveType(schema);
 
+		// schema = {};
 		//remove all keys starting with double $, so they can be used as "metas" properties
-		Object.keys(schema).forEach(key => {
-			if(!key.startsWith("$$")) {
-				return;
-			}
-
-			delete schema[key];
-		});
+		// Object.entries(resolvedSchema).forEach(([key, value]) => {
+		// 	if(key.startsWith("$$")) {
+		// 		return;
+		// 	}
+		//
+		// 	schema[key] = value
+		// });
 
 		const alias = this.aliases[schema.type];
 		if (alias) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -162,6 +162,30 @@ class Validator {
 	}
 
 	/**
+	 * check if the key is a meta key
+	 *
+	 * @param key
+	 * @return {boolean}
+	 */
+	isMetaKey(key) {
+		return key.startsWith("$$");
+	}
+	/**
+	 * will remove all "metas" keys (keys starting with $$)
+	 *
+	 * @param obj
+	 */
+	removeMetasKeys(obj) {
+		Object.keys(obj).forEach(key => {
+			if(!this.isMetaKey(key)) {
+				return;
+			}
+
+			delete obj[key];
+		});
+	}
+
+	/**
 	 * Compile a schema
 	 *
 	 * @param {Object} schema
@@ -204,13 +228,7 @@ class Validator {
 					properties: prevSchema
 				};
 
-				Object.keys(prevSchema).forEach(key => {
-					if(!key.startsWith("$$")) {
-						return;
-					}
-
-					delete prevSchema[key];
-				});
+				this.removeMetasKeys(prevSchema);
 			}
 		}
 
@@ -321,16 +339,6 @@ class Validator {
 	 */
 	getRuleFromSchema(schema) {
 		schema = this.resolveType(schema);
-
-		// schema = {};
-		//remove all keys starting with double $, so they can be used as "metas" properties
-		// Object.entries(resolvedSchema).forEach(([key, value]) => {
-		// 	if(key.startsWith("$$")) {
-		// 		return;
-		// 	}
-		//
-		// 	schema[key] = value
-		// });
 
 		const alias = this.aliases[schema.type];
 		if (alias) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -121,8 +121,8 @@ class Validator {
 			rule.schema.nullable !== false || rule.schema.type === "forbidden" :
 			rule.schema.optional === true || rule.schema.nullable === true || rule.schema.type === "forbidden";
 
-		const ruleHasDefault = considerNullAsAValue ? 
-			rule.schema.default != undefined && rule.schema.default != null : 
+		const ruleHasDefault = considerNullAsAValue ?
+			rule.schema.default != undefined && rule.schema.default != null :
 			rule.schema.default != undefined;
 
 		if (ruleHasDefault) {
@@ -315,6 +315,15 @@ class Validator {
 	 */
 	getRuleFromSchema(schema) {
 		schema = this.resolveType(schema);
+
+		//remove all keys starting with double $, so they can be used as "metas" properties
+		Object.keys(schema).forEach(key => {
+			if(!key.startsWith("$$")) {
+				return;
+			}
+
+			delete schema[key];
+		});
 
 		const alias = this.aliases[schema.type];
 		if (alias) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fastest-validator",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastest-validator",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "The fastest JS validator library for NodeJS",
   "main": "index.js",
   "browser": "dist/index.min.js",

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -1449,63 +1449,102 @@ describe("edge cases", () => {
 
 describe("allow metas starting with $$", () => {
 	const v = new Validator({ useNewCustomCheckerFunction: true });
-	it("should not remove keys from source object", async () => {
-		const schema = {
-			$$foo: {
-				foo: "bar"
-			},
-			name: { type: "string" } };
-		const clonedSchema = {...schema};
-		v.compile(schema);
+	describe("test on schema", () => {
+		it("should not remove keys from source object", async () => {
+			const schema = {
+				$$foo: {
+					foo: "bar"
+				},
+				name: { type: "string" } };
+			const clonedSchema = {...schema};
+			v.compile(schema);
 
-		expect(schema).toStrictEqual(clonedSchema);
+			expect(schema).toStrictEqual(clonedSchema);
+		});
+
+		it("should works with $$root", () => {
+			const schema = {
+				$$foo: {
+					foo: "bar"
+				},
+				$$root: true,
+				type: "email",
+				empty: true
+			};
+			const clonedSchema = {...schema};
+			const check = v.compile(schema);
+
+			expect(check("john.doe@company.net")).toEqual(true);
+			expect(check("")).toEqual(true);
+			expect(schema).toStrictEqual(clonedSchema);
+		});
+
+		it("should works with $$async", async () => {
+			const custom1 = jest.fn().mockResolvedValue("NAME");
+			const schema = {
+				$$foo: {
+					foo: "bar"
+				},
+				$$async: true,
+				name: { type: "string", custom: custom1 },
+			};
+			const clonedSchema = {...schema};
+			const check = v.compile(schema);
+
+			//check schema meta was not changed
+			expect(schema.$$foo).toStrictEqual(clonedSchema.$$foo);
+
+			expect(check.async).toBe(true);
+
+			let obj = {
+				id: 3,
+				name: "John",
+				username: "   john.doe  ",
+				age: 30
+			};
+
+			const res = await check(obj);
+			expect(res).toBe(true);
+
+			expect(custom1).toBeCalledTimes(1);
+			expect(custom1).toBeCalledWith("John", [], schema.name, "name", null, expect.anything());
+		});
 	});
 
-	it("should works with $$root", () => {
-		const schema = {
-			$$foo: {
-				foo: "bar"
-			},
-			$$root: true,
-			type: "email",
-			empty: true
-		};
-		const clonedSchema = {...schema};
-		const check = v.compile(schema);
+	describe("test on rule", () => {
+		it("should not remove keys from source object", async () => {
+			const schema = {
+				name: {
+					$$foo: {
+						foo: "bar"
+					},
+					type: "string"
+				}
+			};
+			const clonedSchema = {...schema};
+			v.compile(schema);
 
-		expect(check("john.doe@company.net")).toEqual(true);
-		expect(check("")).toEqual(true);
-		expect(schema).toStrictEqual(clonedSchema);
-	});
+			expect(schema).toStrictEqual(clonedSchema);
+		});
+		it("should works with $$type", async () => {
+			const schema = {
+				dot: {
+					$$foo: {
+						foo: "bar"
+					},
+					$$type: "object",
+					x: "number",  // object props here
+					y: "number",  // object props here
+				}
+			};
+			const clonedSchema = {...schema};
+			const check = v.compile(schema);
 
-	it("should works with $$async", async () => {
-		const custom1 = jest.fn().mockResolvedValue("NAME");
-		const schema = {
-			$$foo: {
-				foo: "bar"
-			},
-			$$async: true,
-			name: { type: "string", custom: custom1 },
-		};
-		const clonedSchema = {...schema};
-		const check = v.compile(schema);
-
-		//check schema meta was not changed
-		expect(schema.$$foo).toStrictEqual(clonedSchema.$$foo);
-
-		expect(check.async).toBe(true);
-
-		let obj = {
-			id: 3,
-			name: "John",
-			username: "   john.doe  ",
-			age: 30
-		};
-
-		const res = await check(obj);
-		expect(res).toBe(true);
-
-		expect(custom1).toBeCalledTimes(1);
-		expect(custom1).toBeCalledWith("John", [], schema.name, "name", null, expect.anything());
+			expect(schema).toStrictEqual(clonedSchema);
+			expect(check({
+				x: 1,
+				y: 1,
+			})).toBeTruthy();
+		});
 	});
 });

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Validator = require("../lib/validator");
+const {RuleEmail} = require("../index");
 
 describe("Test flat schema", () => {
 	const v = new Validator();
@@ -1443,5 +1444,68 @@ describe("edge cases", () => {
 				type: "string",
 			},
 		]);
+	});
+});
+
+describe("allow metas starting with $$", () => {
+	const v = new Validator({ useNewCustomCheckerFunction: true });
+	it("should not remove keys from source object", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			name: { type: "string" } };
+		const clonedSchema = {...schema};
+		v.compile(schema);
+
+		expect(schema).toStrictEqual(clonedSchema);
+	});
+
+	it("should works with $$root", () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "email",
+			empty: true
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(check("john.doe@company.net")).toEqual(true);
+		expect(check("")).toEqual(true);
+		expect(schema).toStrictEqual(clonedSchema);
+	});
+
+	it("should works with $$async", async () => {
+		const custom1 = jest.fn().mockResolvedValue("NAME");
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$async: true,
+			name: { type: "string", custom: custom1 },
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		//check schema meta was not changed
+		expect(schema.$$foo).toStrictEqual(clonedSchema.$$foo);
+
+		expect(check.async).toBe(true);
+
+		let obj = {
+			id: 3,
+			name: "John",
+			username: "   john.doe  ",
+			age: 30
+		};
+
+		const res = await check(obj);
+		expect(res).toBe(true);
+
+		expect(custom1).toBeCalledTimes(1);
+		expect(custom1).toBeCalledWith("John", [], schema.name, "name", null, expect.anything());
 	});
 });

--- a/test/rules/any.spec.js
+++ b/test/rules/any.spec.js
@@ -39,14 +39,39 @@ describe("Test rule: any", () => {
 			expect(check([])).toEqual(true);
 			expect(check({})).toEqual(true);
 		});
+
+		it("should allow custom metas", async () => {
+			const schema = {
+				$$foo: {
+					foo: "bar"
+				},
+				$$root: true,
+				type: "any",
+				optional: true
+			};
+			const clonedSchema = {...schema};
+			const check = v.compile(schema);
+
+			expect(schema).toStrictEqual(clonedSchema);
+
+			expect(check(null)).toEqual(true);
+			expect(check(undefined)).toEqual(true);
+			expect(check(0)).toEqual(true);
+			expect(check(1)).toEqual(true);
+			expect(check("")).toEqual(true);
+			expect(check("true")).toEqual(true);
+			expect(check("false")).toEqual(true);
+			expect(check([])).toEqual(true);
+			expect(check({})).toEqual(true);
+		});
 	});
 
 	describe("new case (with considerNullAsAValue flag set to true)", () => {
 		const v = new Validator({considerNullAsAValue: true});
-	
+
 		it("should give back true anyway", () => {
 			const check = v.compile({ $$root: true, type: "any" });
-	
+
 			expect(check(null)).toEqual(true);
 			expect(check(undefined)).toEqual([{ type: "required", actual: undefined, message: "The '' field is required." }]);
 			expect(check(0)).toEqual(true);
@@ -57,10 +82,35 @@ describe("Test rule: any", () => {
 			expect(check([])).toEqual(true);
 			expect(check({})).toEqual(true);
 		});
-	
+
 		it("should give back true anyway as optional", () => {
 			const check = v.compile({ $$root: true, type: "any", optional: true });
-	
+
+			expect(check(null)).toEqual(true);
+			expect(check(undefined)).toEqual(true);
+			expect(check(0)).toEqual(true);
+			expect(check(1)).toEqual(true);
+			expect(check("")).toEqual(true);
+			expect(check("true")).toEqual(true);
+			expect(check("false")).toEqual(true);
+			expect(check([])).toEqual(true);
+			expect(check({})).toEqual(true);
+		});
+
+		it("should allow custom metas", async () => {
+			const schema = {
+				$$foo: {
+					foo: "bar"
+				},
+				$$root: true,
+				type: "any",
+				optional: true
+			};
+			const clonedSchema = {...schema};
+			const check = v.compile(schema);
+
+			expect(schema).toStrictEqual(clonedSchema);
+
 			expect(check(null)).toEqual(true);
 			expect(check(undefined)).toEqual(true);
 			expect(check(0)).toEqual(true);

--- a/test/rules/array.spec.js
+++ b/test/rules/array.spec.js
@@ -251,4 +251,34 @@ describe("Test rule: array", () => {
 			});
 		});
 	});
+
+	it("should allow custom metas", async () => {
+		const itemSchema = {
+			$$foo: {
+				foo: "bar"
+			},
+			type: "string",
+		};
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "array",
+			items: itemSchema
+		};
+		const clonedSchema = {...schema};
+		const clonedItemSchema = {...itemSchema};
+		const check = v.compile(schema);
+
+		expect(schema).toStrictEqual(clonedSchema);
+		expect(itemSchema).toStrictEqual(clonedItemSchema);
+
+		expect(check([])).toEqual(true);
+		expect(check(["human"])).toEqual(true);
+		expect(check(["male", 3, "female", true])).toEqual([
+			{ type: "string", field: "[1]", actual: 3, message: "The '[1]' field must be a string." },
+			{ type: "string", field: "[3]", actual: true, message: "The '[3]' field must be a string." }
+		]);
+	});
 });

--- a/test/rules/boolean.spec.js
+++ b/test/rules/boolean.spec.js
@@ -67,4 +67,30 @@ describe("Test rule: boolean", () => {
 		expect(obj).toEqual({ status: true });
 	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "boolean",
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(schema).toStrictEqual(clonedSchema);
+
+		const message = "The '' field must be a boolean.";
+
+		expect(check(0)).toEqual([{ type: "boolean", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "boolean", actual: 1, message }]);
+		expect(check("")).toEqual([{ type: "boolean", actual: "", message }]);
+		expect(check("true")).toEqual([{ type: "boolean", actual: "true", message }]);
+		expect(check("false")).toEqual([{ type: "boolean", actual: "false", message }]);
+		expect(check([])).toEqual([{ type: "boolean", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "boolean", actual: {}, message }]);
+
+		expect(check(false)).toEqual(true);
+		expect(check(true)).toEqual(true);
+	});
 });

--- a/test/rules/class.spec.js
+++ b/test/rules/class.spec.js
@@ -22,4 +22,26 @@ describe("Test rule: class", () => {
 		expect(check({ rawData: Buffer.from([1, 2, 3]) })).toEqual(true);
 		// expect(checker).toBeCalledTimes(1);
 	});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "class",
+			instanceOf: Buffer
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(schema).toStrictEqual(clonedSchema);
+
+		const message = "The '' field must be an instance of the 'Buffer' class.";
+
+		expect(check("1234")).toEqual([{ type: "classInstanceOf", field: undefined, actual: "1234", expected: "Buffer", message }]);
+		expect(check([1, 2, 3])).toEqual([{ type: "classInstanceOf", field: undefined, actual: [1, 2, 3], expected: "Buffer", message }]);
+		expect(check(Buffer.from([1, 2, 3]) )).toEqual(true);
+		expect(check(Buffer.alloc(3) )).toEqual(true);
+	});
 });

--- a/test/rules/currency.spec.js
+++ b/test/rules/currency.spec.js
@@ -62,4 +62,21 @@ describe("Test rule: currency", () => {
 		expect(check("123")).toEqual(true);
 		expect(check("134")).toEqual([{"actual": "134", "field": undefined, "message": "The '' must be a valid currency format", "type": "currency"}]);
 	});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "currency"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(schema).toStrictEqual(clonedSchema);
+
+		expect(check("12.2")).toEqual(true);
+		expect(check("$12.2")).toEqual( [{"actual": "$12.2", "field": undefined, "message": "The '' must be a valid currency format", "type": "currency"}]);
+	});
 });

--- a/test/rules/custom.spec.js
+++ b/test/rules/custom.spec.js
@@ -44,6 +44,28 @@ describe("Test rule: custom v1", () => {
 		expect(checker).toHaveBeenCalledWith(10, schema.weight, "weight", { weight: 10 }, expect.any(Object));
 	});
 
+	it("should allow custom metas", async () => {
+		const checker = jest.fn(() => true);
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "custom",
+			a: 5,
+			check: checker
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(schema).toStrictEqual(clonedSchema);
+
+
+		expect(check(10)).toEqual(true);
+		expect(checker).toHaveBeenCalledTimes(1);
+		//checkFunction should receive the unmodified schema
+		expect(checker).toHaveBeenCalledWith(10, schema, "null", null, expect.any(Object));
+	});
 });
 
 
@@ -105,6 +127,30 @@ describe("Test rule: custom v2", () => {
 
 		expect(check({ name: "John" })).toEqual(true);
 		expect(checker).toHaveBeenCalledTimes(1);
+		expect(checker).toHaveBeenCalledWith({ name: "John" }, [], schema, "$$root", null, expect.any(Object));
+	});
+
+	it("should allow custom metas", async () => {
+		const checker = jest.fn(v => v);
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "object",
+			properties: {
+				name: "string"
+			},
+			custom: checker
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(schema).toStrictEqual(clonedSchema);
+
+		expect(check({ name: "John" })).toEqual(true);
+		expect(checker).toHaveBeenCalledTimes(1);
+		//checkFunction should receive the unmodified schema
 		expect(checker).toHaveBeenCalledWith({ name: "John" }, [], schema, "$$root", null, expect.any(Object));
 	});
 

--- a/test/rules/date.spec.js
+++ b/test/rules/date.spec.js
@@ -63,4 +63,33 @@ describe("Test rule: date", () => {
 		expect(check(obj)).toEqual(true);
 		expect(obj).toEqual({ timestamp: new Date("Wed Mar 25 2015 09:56:24 GMT+0100 (W. Europe Standard Time)") });
 	});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "date"
+		};
+		const clonedSchema = {...schema};
+		expect(schema).toStrictEqual(clonedSchema);
+		const check = v.compile(schema);
+		const message = "The '' field must be a Date.";
+
+		expect(check(0)).toEqual([{ type: "date", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "date", actual: 1, message }]);
+		expect(check("")).toEqual([{ type: "date", actual: "", message }]);
+		expect(check("true")).toEqual([{ type: "date", actual: "true", message }]);
+		expect(check("false")).toEqual([{ type: "date", actual: "false", message }]);
+		expect(check([])).toEqual([{ type: "date", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "date", actual: {}, message }]);
+
+		const now = Date.now();
+		expect(check(now)).toEqual([{ type: "date", actual: now, message }]);
+
+		expect(check(new Date())).toEqual(true);
+		expect(check(new Date(1488876927958))).toEqual(true);
+
+	});
 });

--- a/test/rules/email.spec.js
+++ b/test/rules/email.spec.js
@@ -91,4 +91,21 @@ describe("Test rule: email", () => {
 		expect(check("veryLongEmailAddress@veryLongProviderName.com")).toEqual([{ type: "emailMax", expected: 20, actual: 45, message: "The '' field length must be less than or equal to 20 characters long." }]);
 	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "email",
+			empty: true
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(schema).toStrictEqual(clonedSchema);
+		expect(check("john.doe@company.net")).toEqual(true);
+		expect(check("")).toEqual(true);
+	});
+
 });

--- a/test/rules/enum.spec.js
+++ b/test/rules/enum.spec.js
@@ -23,4 +23,23 @@ describe("Test rule: enum", () => {
 		expect(check(false)).toEqual(true);
 	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "enum",
+			values: ["male", "female"]
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		expect(check("")).toEqual([{ type: "enumValue", expected: "male, female", actual: "", message: "The '' field value 'male, female' does not match any of the allowed values." }]);
+		expect(check("human")).toEqual([{ type: "enumValue", expected: "male, female", actual: "human", message: "The '' field value 'male, female' does not match any of the allowed values." }]);
+		expect(check("male")).toEqual(true);
+		expect(check("female")).toEqual(true);
+	});
 });

--- a/test/rules/equal.spec.js
+++ b/test/rules/equal.spec.js
@@ -48,4 +48,26 @@ describe("Test rule: equal", () => {
 		expect(check({ accept: 1 })).toEqual([{ type: "equalValue", field: "accept", actual: 1, expected: true, message }]);
 		expect(check({ accept: true })).toEqual(true);
 	});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			confirm: {
+				type: "equal",
+				field: "pass"
+			}
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+		const message = "The 'confirm' field value must be equal to 'pass' field value.";
+
+		expect(clonedSchema).toEqual(schema);
+
+		expect(check({ confirm: "abcd"})).toEqual([{ type: "equalField", field: "confirm", actual: "abcd", expected: "pass", message }]);
+		expect(check({ pass: "1234", confirm: "abcd"})).toEqual([{ type: "equalField", field: "confirm", actual: "abcd", expected: "pass", message }]);
+		expect(check({ pass: "1234", confirm: 1234 })).toEqual(true);
+		expect(check({ pass: "1234", confirm: "1234" })).toEqual(true);
+	});
 });

--- a/test/rules/forbidden.spec.js
+++ b/test/rules/forbidden.spec.js
@@ -45,4 +45,30 @@ describe("Test rule: forbidden", () => {
 
 	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "forbidden"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		const message = "The '' field is forbidden.";
+		expect(check(null)).toEqual(true);
+		expect(check(undefined)).toEqual(true);
+		expect(check(0)).toEqual([{ type: "forbidden", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "forbidden", actual: 1, message }]);
+		expect(check("")).toEqual([{ type: "forbidden", actual: "", message }]);
+		expect(check("null")).toEqual([{ type: "forbidden", actual: "null", message }]);
+		expect(check([])).toEqual([{ type: "forbidden", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "forbidden", actual: {}, message }]);
+		expect(check(false)).toEqual([{ type: "forbidden", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "forbidden", actual: true, message }]);
+	});
+
 });

--- a/test/rules/function.spec.js
+++ b/test/rules/function.spec.js
@@ -22,4 +22,33 @@ describe("Test rule: function", () => {
 		expect(check(() => {})).toEqual(true);
 		expect(check(new Function())).toEqual(true);
 	});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "function"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		const message = "The '' field must be a function.";
+
+		expect(check(0)).toEqual([{ type: "function", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "function", actual: 1, message }]);
+		expect(check("")).toEqual([{ type: "function", actual: "", message }]);
+		expect(check("true")).toEqual([{ type: "function", actual: "true", message }]);
+		expect(check([])).toEqual([{ type: "function", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "function", actual: {}, message }]);
+		expect(check(false)).toEqual([{ type: "function", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "function", actual: true, message }]);
+
+		expect(check(function() {})).toEqual(true);
+		expect(check(() => {})).toEqual(true);
+		expect(check(new Function())).toEqual(true);
+	});
 });

--- a/test/rules/luhn.spec.js
+++ b/test/rules/luhn.spec.js
@@ -25,4 +25,34 @@ describe("Test rule: luhn", () => {
 		expect(check("4523-739-8990-1198")).toEqual(true);
 	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "luhn"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		let message = "The '' field must be a string.";
+
+		expect(check(0)).toEqual([{ type: "string", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "string", actual: 1, message }]);
+		expect(check([])).toEqual([{ type: "string", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "string", actual: {}, message }]);
+		expect(check(false)).toEqual([{ type: "string", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "string", actual: true, message }]);
+
+		message = "The '' field must be a valid checksum luhn.";
+		expect(check("")).toEqual([{ type: "luhn", actual: "", message }]);
+		expect(check("true")).toEqual([{ type: "luhn", actual: "true", message }]);
+		expect(check("452373989911198")).toEqual([{ type: "luhn", actual: "452373989911198", message }]);
+		expect(check("452373989901199")).toEqual([{ type: "luhn", actual: "452373989901199", message }]);
+		expect(check("452373989901198")).toEqual(true);
+		expect(check("4523-739-8990-1198")).toEqual(true);
+	});
 });

--- a/test/rules/mac.spec.js
+++ b/test/rules/mac.spec.js
@@ -37,4 +37,46 @@ describe("Test rule: mac", () => {
 		expect(check("01-c8-95-4b-65-fe")).toEqual(true);
 	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "mac"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		let message = "The '' field must be a string.";
+
+		expect(check(0)).toEqual([{ type: "string", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "string", actual: 1, message }]);
+		expect(check([])).toEqual([{ type: "string", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "string", actual: {}, message }]);
+		expect(check(false)).toEqual([{ type: "string", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "string", actual: true, message }]);
+
+		message = "The '' field must be a valid MAC address.";
+		expect(check("")).toEqual([{ type: "mac", actual: "", message }]);
+		expect(check("true")).toEqual([{ type: "mac", actual: "true", message }]);
+		expect(check("018.954B.65FE")).toEqual([{ type: "mac", actual: "018.954B.65FE", message }]);
+		expect(check("01C8.95B.65FE")).toEqual([{ type: "mac", actual: "01C8.95B.65FE", message }]);
+		expect(check("01C8.954B.6FE")).toEqual([{ type: "mac", actual: "01C8.954B.6FE", message }]);
+		expect(check("1-C8-95-4B-65-FE")).toEqual([{ type: "mac", actual: "1-C8-95-4B-65-FE", message }]);
+		expect(check("01-C8-95-4B-65-F")).toEqual([{ type: "mac", actual: "01-C8-95-4B-65-F", message }]);
+		expect(check("01-C8-95-4B-65-FE-A0")).toEqual([{ type: "mac", actual: "01-C8-95-4B-65-FE-A0", message }]);
+		expect(check("1:C8:95:4B:65:FE")).toEqual([{ type: "mac", actual: "1:C8:95:4B:65:FE", message }]);
+		expect(check("01:8:95:4B:65:FE")).toEqual([{ type: "mac", actual: "01:8:95:4B:65:FE", message }]);
+		expect(check("01:C8:95:4B:65:F")).toEqual([{ type: "mac", actual: "01:C8:95:4B:65:F", message }]);
+		expect(check("01:C8:95:4B:65:FE:AF")).toEqual([{ type: "mac", actual: "01:C8:95:4B:65:FE:AF", message }]);
+		expect(check("01:c8:95:4b:65:fe")).toEqual(true);
+		expect(check("01:C8:95:4B:65:FE")).toEqual(true);
+		expect(check("01c8.954b.65fe")).toEqual(true);
+		expect(check("01C8.954B.65FE")).toEqual(true);
+		expect(check("01-C8-95-4B-65-FE")).toEqual(true);
+		expect(check("01-c8-95-4b-65-fe")).toEqual(true);
+	});
 });

--- a/test/rules/multi.spec.js
+++ b/test/rules/multi.spec.js
@@ -185,4 +185,34 @@ describe("Test rule: multi", () => {
 			}
 		});
 	});
+
+
+	it("should allow custom metas", async () => {
+		const fn = jest.fn((v) => v);
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "multi",
+			rules: [
+				{
+					type: "string",
+					custom: fn
+				},
+				{
+					type: "number",
+					custom: fn
+				}
+			]
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		check("s");
+		expect(fn).toBeCalledTimes(1);
+		expect(fn).toBeCalledWith("s", [], schema.rules[0], "$$root", null, expect.any(Object));
+	});
 });

--- a/test/rules/number.spec.js
+++ b/test/rules/number.spec.js
@@ -155,4 +155,35 @@ describe("Test rule: number", () => {
 		expect(obj).toEqual({ age: -45 });
 	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "number"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		const message = "The '' field must be a number.";
+
+		expect(check("")).toEqual([{ type: "number", actual: "", message }]);
+		expect(check("test")).toEqual([{ type: "number", actual: "test", message }]);
+		expect(check("1")).toEqual([{ type: "number", actual: "1", message }]);
+		expect(check([])).toEqual([{ type: "number", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "number", actual: {}, message }]);
+		expect(check(false)).toEqual([{ type: "number", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "number", actual: true, message }]);
+		expect(check(NaN)).toEqual([{ type: "number", actual: NaN, message }]);
+		expect(check(Number.POSITIVE_INFINITY)).toEqual([{ type: "number", actual: Number.POSITIVE_INFINITY, message }]);
+		expect(check(Number.NEGATIVE_INFINITY)).toEqual([{ type: "number", actual: Number.NEGATIVE_INFINITY, message }]);
+
+		expect(check(0)).toEqual(true);
+		expect(check(5)).toEqual(true);
+		expect(check(-24)).toEqual(true);
+		expect(check(5.45)).toEqual(true);
+	});
 });

--- a/test/rules/object.spec.js
+++ b/test/rules/object.spec.js
@@ -167,4 +167,29 @@ describe("Test rule: object", () => {
 		});
 
 	});
+
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "object"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+		const message = "The '' must be an Object.";
+
+		expect(check(0)).toEqual([{ type: "object", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "object", actual: 1, message }]);
+		expect(check("")).toEqual([{ type: "object", actual: "", message }]);
+		expect(check(false)).toEqual([{ type: "object", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "object", actual: true, message }]);
+		expect(check([])).toEqual([{ type: "object", actual: [], message }]);
+		expect(check({})).toEqual(true);
+		expect(check({ a: "John" })).toEqual(true);
+	});
 });

--- a/test/rules/objectID.spec.js
+++ b/test/rules/objectID.spec.js
@@ -2,16 +2,16 @@
 
 const Validator = require("../../lib/validator");
 const v = new Validator();
-const { ObjectID } = require("mongodb");
+const { ObjectId } = require("mongodb");
 
 describe("Test rule: objectID", () => {
 
 	it("should validate ObjectID", () => {
-		const check = v.compile({ id: { type: "objectID", ObjectID } });
+		const check = v.compile({ id: { type: "objectID", ObjectID: ObjectId } });
 		const message = "The 'id' field must be an valid ObjectID";
 
 		expect(check({ id: "5f082780b00cc7401fb8"})).toEqual([{ type: "objectID", field: "id", actual: "5f082780b00cc7401fb8", message }]);
-		expect(check({ id: new ObjectID() })).toEqual(true);
+		expect(check({ id: new ObjectId() })).toEqual(true);
 
 		const o = { id: "5f082780b00cc7401fb8e8fc" };
 		expect(check(o)).toEqual(true);
@@ -19,18 +19,18 @@ describe("Test rule: objectID", () => {
 	});
 
 	it("should convert hexString-objectID to ObjectID", () => {
-		const check = v.compile({ id: { type: "objectID", ObjectID, convert: true } });
-		const  oid = new ObjectID();
+		const check = v.compile({ id: { type: "objectID", ObjectID: ObjectId, convert: true } });
+		const  oid = new ObjectId();
 		const o = { id: oid.toHexString() };
 
 		expect(check(o)).toEqual(true);
-		expect(o.id).toBeInstanceOf(ObjectID);
+		expect(o.id).toBeInstanceOf(ObjectId);
 		expect(o.id).toEqual(oid);
 	});
 
 	it("should convert hexString-objectID to hexString", () => {
-		const check = v.compile({ id: { type: "objectID", ObjectID, convert: "hexString" } });
-		const  oid = new ObjectID();
+		const check = v.compile({ id: { type: "objectID", ObjectID: ObjectId, convert: "hexString" } });
+		const  oid = new ObjectId();
 		const  oidStr = oid.toHexString();
 		const o = { id: oid };
 
@@ -41,10 +41,34 @@ describe("Test rule: objectID", () => {
 
 	it("should catch hexString problems when convert: true", () => {
 		const message = "The 'id' field must be an valid ObjectID";
-		const check = v.compile({ id: { type: "objectID", ObjectID, convert: true } });
+		const check = v.compile({ id: { type: "objectID", ObjectID: ObjectId, convert: true } });
 
 		const badID = "5f082780b00cc7401fb8";
 		const o = { id: badID };
 		expect(check(o)).toEqual([{ type: "objectID", field: "id", actual: badID, message }]);
+	});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			id: {
+				type: "objectID",
+				ObjectID: ObjectId
+			}
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+		const message = "The 'id' field must be an valid ObjectID";
+
+		expect(check({ id: "5f082780b00cc7401fb8"})).toEqual([{ type: "objectID", field: "id", actual: "5f082780b00cc7401fb8", message }]);
+		expect(check({ id: new ObjectId() })).toEqual(true);
+
+		const o = { id: "5f082780b00cc7401fb8e8fc" };
+		expect(check(o)).toEqual(true);
+		expect(o.id).toBe("5f082780b00cc7401fb8e8fc");
 	});
 });

--- a/test/rules/record.spec.js
+++ b/test/rules/record.spec.js
@@ -107,4 +107,29 @@ describe("Test rule: record", () => {
 
 			expect(check({ John: value })).toEqual(true);
 		});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "record"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		const message = "The '' must be an Object.";
+
+		expect(check(0)).toEqual([{ type: "record", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "record", actual: 1, message }]);
+		expect(check("")).toEqual([{ type: "record", actual: "", message }]);
+		expect(check(false)).toEqual([{ type: "record", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "record", actual: true, message }]);
+		expect(check([])).toEqual([{ type: "record", actual: [], message }]);
+		expect(check({})).toEqual(true);
+		expect(check({ a: "John" })).toEqual(true);
+	});
 });

--- a/test/rules/string.spec.js
+++ b/test/rules/string.spec.js
@@ -350,4 +350,29 @@ describe("Test rule: string", () => {
 		});
 	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "string"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		const message = "The '' field must be a string.";
+
+		expect(check(0)).toEqual([{ type: "string", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "string", actual: 1, message }]);
+		expect(check([])).toEqual([{ type: "string", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "string", actual: {}, message }]);
+		expect(check(false)).toEqual([{ type: "string", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "string", actual: true, message }]);
+
+		expect(check("")).toEqual(true);
+		expect(check("test")).toEqual(true);
+	});
 });

--- a/test/rules/tuple.spec.js
+++ b/test/rules/tuple.spec.js
@@ -242,4 +242,34 @@ describe("Test rule: tuple", () => {
 			expect(o.a).toEqual([2, 4]);
 		});
 	});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "tuple"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		const message = "The '' field must be an array.";
+
+		expect(check(0)).toEqual([{ type: "tuple", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "tuple", actual: 1, message }]);
+		expect(check({})).toEqual([{ type: "tuple", actual: {}, message }]);
+		expect(check(false)).toEqual([
+			{ type: "tuple", actual: false, message }
+		]);
+		expect(check(true)).toEqual([{ type: "tuple", actual: true, message }]);
+		expect(check("")).toEqual([{ type: "tuple", actual: "", message }]);
+		expect(check("test")).toEqual([
+			{ type: "tuple", actual: "test", message }
+		]);
+
+		expect(check([])).toEqual(true);
+	});
 });

--- a/test/rules/url.spec.js
+++ b/test/rules/url.spec.js
@@ -38,8 +38,45 @@ describe("Test rule: url", () => {
 		expect(check("http://github.com/icebob/fastest-validator")).toEqual(true);
 		expect(check("http://clipboard.space")).toEqual(true);
 		expect(check("https://localhost:3000/?id=5&name=Test#result")).toEqual(true);
+	});
 
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "url"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
 
+		expect(clonedSchema).toEqual(schema);
 
+		let message = "The '' field must be a string.";
+
+		expect(check(0)).toEqual([{ type: "string", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "string", actual: 1, message }]);
+		expect(check([])).toEqual([{ type: "string", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "string", actual: {}, message }]);
+		expect(check(false)).toEqual([{ type: "string", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "string", actual: true, message }]);
+
+		message = "The '' field must be a valid URL.";
+		expect(check("")).toEqual([{ type: "urlEmpty", actual: "", message: "The '' field must not be empty." }]);
+		expect(check("true")).toEqual([{ type: "url", actual: "true", message }]);
+		expect(check("abcdefg")).toEqual([{ type: "url", actual: "abcdefg", message }]);
+		expect(check("1234.c")).toEqual([{ type: "url", actual: "1234.c", message }]);
+		expect(check("gmail.company1234")).toEqual([{ type: "url", actual: "gmail.company1234", message }]);
+		expect(check("@gmail.com")).toEqual([{ type: "url", actual: "@gmail.com", message }]);
+		expect(check("https://")).toEqual([{ type: "url", actual: "https://", message }]);
+
+		expect(check("http://www.google.com")).toEqual(true);
+		expect(check("https://google.com")).toEqual(true);
+		expect(check("http://nasa.gov")).toEqual(true);
+		expect(check("https://github.com")).toEqual(true);
+		expect(check("http://github.com/icebob/fastest-validator")).toEqual(true);
+		expect(check("http://clipboard.space")).toEqual(true);
+		expect(check("https://localhost:3000/?id=5&name=Test#result")).toEqual(true);
 	});
 });

--- a/test/rules/uuid.spec.js
+++ b/test/rules/uuid.spec.js
@@ -89,4 +89,34 @@ describe("Test rule: uuid", () => {
 		expect(check5("FDDA765F-FC57-5604-A269-52A7DF8164EC")).toEqual(true);
 		expect(check6("A9030619-8514-6970-E0F9-81B9CEB08A5F")).toEqual(true);
 	});
+
+	it("should allow custom metas", async () => {
+		const schema = {
+			$$foo: {
+				foo: "bar"
+			},
+			$$root: true,
+			type: "uuid"
+		};
+		const clonedSchema = {...schema};
+		const check = v.compile(schema);
+
+		expect(clonedSchema).toEqual(schema);
+
+		let message = "The '' field must be a string.";
+
+		expect(check(0)).toEqual([{ type: "string", actual: 0, message }]);
+		expect(check(1)).toEqual([{ type: "string", actual: 1, message }]);
+		expect(check([])).toEqual([{ type: "string", actual: [], message }]);
+		expect(check({})).toEqual([{ type: "string", actual: {}, message }]);
+		expect(check(false)).toEqual([{ type: "string", actual: false, message }]);
+		expect(check(true)).toEqual([{ type: "string", actual: true, message }]);
+
+		message = "The '' field must be a valid UUID.";
+		expect(check("")).toEqual([{ type: "uuid", actual: "", message }]);
+		expect(check("true")).toEqual([{ type: "uuid", actual: "true", message }]);
+		expect(check("10000000-0000-0000-0000-000000000000")).toEqual([{ type: "uuid", actual: "10000000-0000-0000-0000-000000000000", message }]);
+		expect(check("1234567-1234-1234-1234-1234567890ab")).toEqual([{ type: "uuid", actual: "1234567-1234-1234-1234-1234567890ab", message }]);
+		expect(check("12345678-1234-1234-1234-1234567890ab")).toEqual(true);
+	});
 });


### PR DESCRIPTION
Fix #338 

I think it can be useful to add some metas in the schemas / rules
 
like : 
```js
    dot: {
        $$metas: {
          openapiName: 'dot'
        },
        $$type: "object",
        x: "number", // object props here
        y: "number", // object props here
    }
```

I think it can be usefull to reuse the validation params to do others things ( like here, generating openapi from params ) . 

The keys starting with $$ can be just skipped from the validation, categorized as "system properties" ? (this can also allow to add other systems properties without breaking changes) . 

---

I've checked with the already existing keys, to remove the metas after they are used

 - `$$async` seems to be used only in `compile` (so before `getRuleFromSchema`) / same for `$$root` / seems the same for `$$strict`
 - `$$type` seems to be used in `resolveType` (in `getRuleFromSchema`) only, and only on current schema ( it will call `getRuleFromSchema` only on sub rules ), and so I removed the $$ after 
 
 
---

I also update typescript to allow other libraries to do things like : 

```typescript
declare module 'fastest-validator' {
    interface ValidationSchemaMetaKeys {
        $$metas?: {
          foo: string;
          bar: string;
        }
    }
}
```

 
TODO : 
- [ ] tests ? (the main test is to allow all other tests, without breaking them)
- [ ] do the same on a rule