### PR TITLE
replace deprecated method substr

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -377,11 +377,11 @@ class Validator {
 			};
 		}
 
-		p.slice(1).map((s) => {
+		p.slice(1).forEach((s) => {
 			const idx = s.indexOf(":");
 			if (idx !== -1) {
-				const key = s.substr(0, idx).trim();
-				let value = s.substr(idx + 1).trim();
+				const key = s.substring(0, idx).trim();
+				let value = s.substring(idx + 1).trim();
 				if (value === "true" || value === "false")
 					value = value === "true";
 				else if (!Number.isNaN(Number(value))) {


### PR DESCRIPTION
replace deprecated `substr` with `substring`

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr