### PR TITLE
Use TSTyche to test types

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,3 +27,17 @@ jobs:
         npm run build
       env:
         CI: true
+
+  test-types:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: lts/*
+    - name: npm install, build, and test types
+      run: |
+        npm ci
+        npm run build
+        npm run test:types -- --target 4.6,5.0,latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -5389,22 +5389,6 @@
         "error-stack-parser": "*"
       }
     },
-    "@types/eslint": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
-      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-      "dev": true
-    },
     "@types/fs-extra": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.2.tgz",
@@ -5466,12 +5450,6 @@
         "jest-diff": "^27.0.0",
         "pretty-format": "^27.0.0"
       }
-    },
-    "@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
     },
     "@types/lodash": {
       "version": "4.14.182",
@@ -6221,15 +6199,6 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.0",
         "picocolors": "^1.0.0"
-      }
-    },
-    "bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "requires": {
-        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -7624,79 +7593,6 @@
         }
       }
     },
-    "eslint-formatter-pretty": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
-      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
-      "dev": true,
-      "requires": {
-        "@types/eslint": "^7.2.13",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "eslint-rule-docs": "^1.1.5",
-        "log-symbols": "^4.0.0",
-        "plur": "^4.0.0",
-        "string-width": "^4.2.0",
-        "supports-hyperlinks": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "eslint-rule-docs": {
-      "version": "1.1.235",
-      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
-      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
-      "dev": true
-    },
     "eslint-scope": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -8707,12 +8603,6 @@
         }
       }
     },
-    "irregular-plurals": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
-      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
-      "dev": true
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -8726,15 +8616,6 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-ci": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
-      "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^3.1.1"
       }
     },
     "is-core-module": {
@@ -11647,71 +11528,6 @@
         }
       }
     },
-    "jest-util": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.5.tgz",
-      "integrity": "sha512-QRhDC6XxISntMzFRd/OQ6TGsjbzA5ONO0tlAj2ElHs155x1aEr0rkYJBEysG6H/gZVH3oGFzCdAB/GA8leh8NQ==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.2.5",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
-        "is-ci": "^3.0.0",
-        "picomatch": "^2.2.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "jest-validate": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.5.1.tgz",
@@ -12122,12 +11938,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.merge": {
@@ -13032,15 +12842,6 @@
       "dev": true,
       "requires": {
         "semver-compare": "^1.0.0"
-      }
-    },
-    "plur": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
-      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
-      "dev": true,
-      "requires": {
-        "irregular-plurals": "^3.2.0"
       }
     },
     "postcss": {
@@ -14280,22 +14081,6 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
-    "ts-jest": {
-      "version": "27.0.7",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.7.tgz",
-      "integrity": "sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==",
-      "dev": true,
-      "requires": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^27.0.0",
-        "json5": "2.x",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "20.x"
-      }
-    },
     "ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -14331,32 +14116,16 @@
         }
       }
     },
-    "tsd": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.22.0.tgz",
-      "integrity": "sha512-NH+tfEDQ0Ze8gH7TorB6IxYybD+M68EYawe45YNVrbQcydNBfdQHP9IiD0QbnqmwNXrv+l9GAiULT68mo4q/xA==",
-      "dev": true,
-      "requires": {
-        "@tsd/typescript": "~4.7.4",
-        "eslint-formatter-pretty": "^4.1.0",
-        "globby": "^11.0.1",
-        "meow": "^9.0.0",
-        "path-exists": "^4.0.0",
-        "read-pkg-up": "^7.0.0"
-      },
-      "dependencies": {
-        "@tsd/typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-jbtC+RgKZ9Kk65zuRZbKLTACf+tvFW4Rfq0JEMXrlmV3P3yme+Hm+pnb5fJRyt61SjIitcrC810wj7+1tgsEmg==",
-          "dev": true
-        }
-      }
-    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "tstyche": {
+      "version": "3.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-3.0.0-rc.2.tgz",
+      "integrity": "sha512-sG7nX6igb9CoRGUku1mGS5LhwHgQd1zpXyAO8vF7Jt3atFRf0iAJ1+Od4cNqdw5GBCcIxi+g6CqG8sfFX2WCfQ==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "postdeps": "npm test",
     "coverall": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test": "jest --coverage",
-    "test:travis": "npm test"
+    "test:travis": "npm test",
+    "test:types": "tstyche"
   },
   "repository": {
     "type": "git",
@@ -61,9 +62,8 @@
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-uglify-es": "^0.0.1",
-    "ts-jest": "^27.0.7",
     "ts-node": "^10.9.1",
-    "tsd": "^0.22.0",
+    "tstyche": "^3.0.0-rc.2",
     "typescript": "^4.7.4"
   },
   "jest": {
@@ -73,14 +73,6 @@
     "roots": [
       "../test"
     ],
-    "transform": {
-      "^.+\\.(ts|tsx)$": "ts-jest"
-    },
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "test/typescript/tsconfig.json",
-        "diagnostics": true
-      }
-    }
+    "testMatch": ["!**/test/typescript/**/*"]
   }
 }

--- a/test/typescript/integration.spec.ts
+++ b/test/typescript/integration.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from '../../';
 
 describe('TypeScript Definitions', () => {

--- a/test/typescript/messages.spec.ts
+++ b/test/typescript/messages.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../index.d.ts" /> // here we make a reference to exists module definition
+import { describe, it } from "tstyche";
 import { BuiltInMessages } from "../../";
 
 const msg: BuiltInMessages = require("../../lib/messages");

--- a/test/typescript/rules/any.spec.ts
+++ b/test/typescript/rules/any.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from "../../../";
 
 const v = new Validator();

--- a/test/typescript/rules/array.spec.ts
+++ b/test/typescript/rules/array.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleArray } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/boolean.spec.ts
+++ b/test/typescript/rules/boolean.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from "../../../";
 
 const v = new Validator();

--- a/test/typescript/rules/class.spec.ts
+++ b/test/typescript/rules/class.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/custom.spec.ts
+++ b/test/typescript/rules/custom.spec.ts
@@ -1,9 +1,8 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleCustom, ValidationSchema, CheckerFunction } from '../../../';
-
 
 describe("Test rule: custom v1", () => {
 	const v = new Validator();
-
 
 	it("should call custom checker", () => {
 		const checker = jest.fn(() => true);

--- a/test/typescript/rules/custom_messages.spec.ts
+++ b/test/typescript/rules/custom_messages.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleBoolean, RuleString, ValidationSchema } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/date.spec.ts
+++ b/test/typescript/rules/date.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/email.spec.ts
+++ b/test/typescript/rules/email.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleEmail, RuleURL } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/enum.spec.ts
+++ b/test/typescript/rules/enum.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleEnum } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/equal.spec.ts
+++ b/test/typescript/rules/equal.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/forbidden.spec.ts
+++ b/test/typescript/rules/forbidden.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/function.spec.ts
+++ b/test/typescript/rules/function.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/luhn.spec.ts
+++ b/test/typescript/rules/luhn.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/mac.spec.ts
+++ b/test/typescript/rules/mac.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/number.spec.ts
+++ b/test/typescript/rules/number.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleNumber, ValidationSchema } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/object.spec.ts
+++ b/test/typescript/rules/object.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleObject } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/objectID.spec.ts
+++ b/test/typescript/rules/objectID.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleObjectID } from '../../../';
 import { ObjectID } from 'mongodb';
 

--- a/test/typescript/rules/string.spec.ts
+++ b/test/typescript/rules/string.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleString } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/tuple.spec.ts
+++ b/test/typescript/rules/tuple.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleTuple, ValidationError } from '../../../';
 
 const v = new Validator({

--- a/test/typescript/rules/url.spec.ts
+++ b/test/typescript/rules/url.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleURL } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/rules/uuid.spec.ts
+++ b/test/typescript/rules/uuid.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "tstyche";
 import Validator, { RuleUUID } from '../../../';
 
 const v = new Validator();

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -20,5 +20,5 @@
         "baseUrl": ".",
         "allowJs": true
     },
-    "include": ["test", "lib", "index.d.ts", "index.js"]
+	"include": ["**/*"],
 }

--- a/test/typescript/validator.spec.ts
+++ b/test/typescript/validator.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../index.d.ts" /> // here we make a reference to exists module definition
+import { describe, it } from "tstyche";
 import Validator from '../../';
 
 describe('TypeScript Definitions', () => {

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://tstyche.org/schemas/config.json",
+	"testFileMatch": [
+		"test/typescript/**/*.spec.*"
+	]
+}


### PR DESCRIPTION
Closes #232

The referenced issue is proposing to use `tsd` to test types. I would like to suggest to use TSTyche (https://github.com/tstyche/tstyche) instead.

It does all what `tsd` can do and much more. Here are few reasons to choose TSTyche:

- it is lightweight only 225kB (instead of 48MB);
- is able to test using specific TypeScript version (`--target 4.6,5.0,latest`, this simple);
- has `describe()` and `it()` helpers that are already used in the test files of this project;
- `--watch` mode, better performance, detailed documentation (https://tstyche.org);
- and more.

---

Here is what is done in this PR:

- added `tstyche` and removed redundant dependencies;
- included `describe()` and `it()` helpers in the test files.

With this setup TSTyche type checks the test files. Just try running:

- `npx tstyche`, to run the tests using the installed TypeScript version;
- `npx tstyche --target 4.6,5.0,latest`, to typecheck using different versions of TypeScript;
- `npx tstyche date`, to run only a single file;
- `npx tstyche date --only sanitize`, to run only a single `test()` in that file.