### PR TITLE
Add support enum list into number validation

### DIFF
--- a/lib/rules/number.js
+++ b/lib/rules/number.js
@@ -60,6 +60,16 @@ module.exports = function({ schema, messages }, path, context) {
 		`);
 	}
 
+	// Check enum value
+	if (schema.enum === true) {
+		const enumNum = JSON.stringify(schema.enum);
+		src.push(`
+			if (${enumNum}.indexOf(value) === -1) {
+				${this.makeError({ type: "numberEnum", expected: "\"" + schema.enum.join(", ") + "\"", actual: "origValue", messages })}
+			}
+		`);
+	}
+
 	// Check integer
 	if (schema.integer === true) {
 		src.push(`


### PR DESCRIPTION
Add support enum list into number validation.
Ex:
type: { type: 'number', enum: [1, 3, 5,  7] },