### PR TITLE
Feat: Add `step` property for `number` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,7 @@ Name                | Default text
 `numberEqual`	| The '{field}' field must be equal to {expected}.
 `numberNotEqual`	| The '{field}' field can't be equal to {expected}.
 `numberInteger`	| The '{field}' field must be an integer.
+`numberStep`	| The '{field}' field must be a multiple of {expected}.
 `numberPositive`	| The '{field}' field must be a positive number.
 `numberNegative`	| The '{field}' field must be a negative number.
 `array`	| The '{field}' field must be an array.

--- a/index.d.ts
+++ b/index.d.ts
@@ -352,6 +352,10 @@ export interface RuleNumber extends RuleCustom {
 	 */
 	integer?: boolean;
 	/**
+	 * The stepping interval for the input value
+	 */
+	step?: number;
+	/**
 	 * The value must be greater than zero
 	 * @default false
 	 */
@@ -731,6 +735,10 @@ export interface BuiltInMessages {
 	 * The '{field}' field must be an integer.
 	 */
 	numberInteger?: string;
+	/**
+	 * The '{field}' field must be a multiple of {expected}.
+	 */
+	numberStep?: string;
 	/**
 	 * The '{field}' field must be a positive number.
 	 */

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -25,6 +25,7 @@ module.exports = {
 	numberEqual: "The '{field}' field must be equal to {expected}.",
 	numberNotEqual: "The '{field}' field can't be equal to {expected}.",
 	numberInteger: "The '{field}' field must be an integer.",
+	numberStep: "The '{field}' field must be a multiple of {expected}.",
 	numberPositive: "The '{field}' field must be a positive number.",
 	numberNegative: "The '{field}' field must be a negative number.",
 

--- a/lib/rules/number.js
+++ b/lib/rules/number.js
@@ -21,7 +21,7 @@ module.exports = function({ schema, messages }, path, context) {
 
 	src.push(`
 		if (typeof value !== "number" || isNaN(value) || !isFinite(value)) {
-			${this.makeError({ type: "number",  actual: "origValue", messages })}
+			${this.makeError({ type: "number", actual: "origValue", messages })}
 			return value;
 		}
 	`);
@@ -64,29 +64,56 @@ module.exports = function({ schema, messages }, path, context) {
 	if (schema.integer === true) {
 		src.push(`
 			if (value % 1 !== 0) {
-				${this.makeError({ type: "numberInteger",  actual: "origValue", messages })}
+				${this.makeError({ type: "numberInteger", actual: "origValue", messages })}
 			}
 		`);
 	}
 
 	// Check step
 	if (schema.step != null) {
-		if (!(schema.step > 0))
+		if (schema.step <= 0 || !Number.isFinite(schema.step))
 			throw new Error(`Invalid '${schema.type}' schema. The 'step' field must be a positive number.`);
+		
+		const errorSrc = this.makeError({ type: "numberStep", expected: schema.step, actual: "origValue", messages });
 
-		src.push(`
-			const ratio = value / ${schema.step};
-			if (Math.abs(Math.round(ratio) - ratio) > 1e-10) {
-				${this.makeError({ type: "numberStep", expected: schema.step, actual: "origValue", messages })}
-			}
-		`);
+		if (Number.isInteger(schema.step)) 
+			src.push(`
+				if (value % ${schema.step} !== 0) {
+					${errorSrc}
+				}
+			`)
+		else {
+			const stepDecimals = schema.step.toString().split('.')[1].length
+			const multiplier = Math.pow(10, stepDecimals);
+			const stepInt = Math.round(schema.step * multiplier);
+
+			src.push(`
+				if (!Number.isFinite(value)) {
+					${errorSrc}
+				} else {
+					const valStr = value.toString();
+					const valDotIdx = valStr.indexOf('.');
+					const valDecimals = valDotIdx !== -1 ? valStr.length - valDotIdx - 1 : 0;
+
+					if (valDecimals > ${stepDecimals}) {
+						${errorSrc}
+					} else {
+						const valInt = Math.round(value * ${multiplier});
+	
+						if (valInt % ${stepInt} !== 0) {
+							${errorSrc}
+						}
+					}
+				}
+			`);
+		}
 	}
 
 	// Check positive
 	if (schema.positive === true) {
 		src.push(`
 			if (value <= 0) {
-				${this.makeError({ type: "numberPositive",  actual: "origValue", messages })}
+				${this.makeError({ type: "numberPositive", actual: "origValue", messages })}
 			}
 		`);
 	}
@@ -95,7 +122,7 @@ module.exports = function({ schema, messages }, path, context) {
 	if (schema.negative === true) {
 		src.push(`
 			if (value >= 0) {
-				${this.makeError({ type: "numberNegative",  actual: "origValue", messages })}
+				${this.makeError({ type: "numberNegative", actual: "origValue", messages })}
 			}
 		`);
 	}

--- a/lib/rules/number.js
+++ b/lib/rules/number.js
@@ -69,6 +69,15 @@ module.exports = function({ schema, messages }, path, context) {
 		`);
 	}
 
+	// Check step
+	if (schema.step != null) {
+		src.push(`
+			if (value % ${schema.step} !== 0) {
+				${this.makeError({ type: "numberStep", expected: schema.step, actual: "origValue", messages })}
+			}
+		`);
+	}
+
 	// Check positive
 	if (schema.positive === true) {
 		src.push(`

--- a/lib/rules/number.js
+++ b/lib/rules/number.js
@@ -71,8 +71,12 @@ module.exports = function({ schema, messages }, path, context) {
 
 	// Check step
 	if (schema.step != null) {
+		if (!(schema.step > 0))
+			throw new Error(`Invalid '${schema.type}' schema. The 'step' field must be a positive number.`);
+
 		src.push(`
-			if (value % ${schema.step} !== 0) {
+			const ratio = value / ${schema.step};
+			if (Math.abs(Math.round(ratio) - ratio) > 1e-10) {
 				${this.makeError({ type: "numberStep", expected: schema.step, actual: "origValue", messages })}
 			}
 		`);

--- a/test/messages.spec.js
+++ b/test/messages.spec.js
@@ -22,6 +22,7 @@ describe("Test Messages", () => {
 		expect(msg.numberEqual).toBeDefined();
 		expect(msg.numberNotEqual).toBeDefined();
 		expect(msg.numberInteger).toBeDefined();
+		expect(msg.numberStep).toBeDefined();
 		expect(msg.numberPositive).toBeDefined();
 		expect(msg.numberNegative).toBeDefined();
 		expect(msg.array).toBeDefined();

--- a/test/rules/number.spec.js
+++ b/test/rules/number.spec.js
@@ -82,17 +82,41 @@ describe("Test rule: number", () => {
 		expect(check(20)).toEqual(true);
 	});
 
+	it("check schema's 'step' field type", () => {
+		const message =	"Invalid 'number' schema. The 'step' field must be a positive number.";
+
+		expect(() => v.compile({ $$root: true, type: "number", step: 0 })).toThrow(message);
+	});
+
 	it("check step", () => {
 		const check = v.compile({ $$root: true, type: "number", step: 10 });
 		const message = "The '' field must be a multiple of 10.";
 
+		expect(check(15)).toEqual([{ type: "numberStep", expected: 10, actual: 15, message }]);
 		expect(check(8.5)).toEqual([{ type: "numberStep", expected: 10, actual: 8.5, message }]);
 		expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 10, actual: -5.5, message }]);
-		expect(check(15)).toEqual([{ type: "numberStep", expected: 10, actual: 15, message }]);
+		
 		expect(check(0)).toEqual(true);
-		expect(check(-20)).toEqual(true);
 		expect(check(20)).toEqual(true);
+		expect(check(-20)).toEqual(true);
 		expect(check(100)).toEqual(true);
+	});
+
+	it("check step (float)", () => {
+		const check = v.compile({ $$root: true, type: "number", step: 0.2 });
+		const message = "The '' field must be a multiple of 0.2.";
+
+		expect(check(1.1)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.1, message }]);
+		expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 0.2, actual: -5.5, message }]);
+		expect(check(0.20001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 0.20001, message }]);
+
+		expect(check(0)).toEqual(true);
+		expect(check(2)).toEqual(true);
+		expect(check(1.4)).toEqual(true);
+		expect(check(-20.2)).toEqual(true);
+
+		expect(check(1.4000000001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.4000000001, message }]);
+		expect(check(1.40000000001)).toEqual(true); // will pass due to precision tolerance
 	});
 
 	it("check positive number", () => {

--- a/test/rules/number.spec.js
+++ b/test/rules/number.spec.js
@@ -98,8 +98,6 @@ describe("Test rule: number", () => {
 		expect(check(15)).toEqual([{ type: "numberStep", expected: 10, actual: 15, message }]);
 		expect(check(8.5)).toEqual([{ type: "numberStep", expected: 10, actual: 8.5, message }]);
 		expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 10, actual: -5.5, message }]);
-		expect(check(NaN)).toEqual([{ type: "numberStep", expected: 10, actual: NaN, message }]);
-		expect(check(Infinity)).toEqual([{ type: "numberStep", expected: 10, actual: Infinity, message }]);
 		
 		expect(check(0)).toEqual(true);
 		expect(check(20)).toEqual(true);
@@ -114,8 +112,6 @@ describe("Test rule: number", () => {
 		expect(check(1.1)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.1, message }]);
 		expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 0.2, actual: -5.5, message }]);
 		expect(check(0.20001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 0.20001, message }]);
-		expect(check(NaN)).toEqual([{ type: "numberStep", expected: 0.2, actual: NaN, message }]);
-		expect(check(Infinity)).toEqual([{ type: "numberStep", expected: 0.2, actual: Infinity, message }]);
 
 		expect(check(0)).toEqual(true);
 		expect(check(2)).toEqual(true);

--- a/test/rules/number.spec.js
+++ b/test/rules/number.spec.js
@@ -88,6 +88,7 @@ describe("Test rule: number", () => {
 		expect(() => v.compile({ $$root: true, type: "number", step: 0 })).toThrow(message);
 		expect(() => v.compile({ $$root: true, type: "number", step: -1 })).toThrow(message);
 		expect(() => v.compile({ $$root: true, type: "number", step: NaN })).toThrow(message);
+		expect(() => v.compile({ $$root: true, type: "number", step: Infinity })).toThrow(message);
 	});
 
 	it("check step", () => {
@@ -97,6 +98,8 @@ describe("Test rule: number", () => {
 		expect(check(15)).toEqual([{ type: "numberStep", expected: 10, actual: 15, message }]);
 		expect(check(8.5)).toEqual([{ type: "numberStep", expected: 10, actual: 8.5, message }]);
 		expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 10, actual: -5.5, message }]);
+		expect(check(NaN)).toEqual([{ type: "numberStep", expected: 10, actual: NaN, message }]);
+		expect(check(Infinity)).toEqual([{ type: "numberStep", expected: 10, actual: Infinity, message }]);
 		
 		expect(check(0)).toEqual(true);
 		expect(check(20)).toEqual(true);
@@ -111,6 +114,8 @@ describe("Test rule: number", () => {
 		expect(check(1.1)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.1, message }]);
 		expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 0.2, actual: -5.5, message }]);
 		expect(check(0.20001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 0.20001, message }]);
+		expect(check(NaN)).toEqual([{ type: "numberStep", expected: 0.2, actual: NaN, message }]);
+		expect(check(Infinity)).toEqual([{ type: "numberStep", expected: 0.2, actual: Infinity, message }]);
 
 		expect(check(0)).toEqual(true);
 		expect(check(2)).toEqual(true);
@@ -118,7 +123,6 @@ describe("Test rule: number", () => {
 		expect(check(-20.2)).toEqual(true);
 
 		expect(check(1.4000000001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.4000000001, message }]);
-		expect(check(1.40000000001)).toEqual(true); // will pass due to precision tolerance
 	});
 
 	it("check positive number", () => {

--- a/test/rules/number.spec.js
+++ b/test/rules/number.spec.js
@@ -86,6 +86,8 @@ describe("Test rule: number", () => {
 		const message =	"Invalid 'number' schema. The 'step' field must be a positive number.";
 
 		expect(() => v.compile({ $$root: true, type: "number", step: 0 })).toThrow(message);
+		expect(() => v.compile({ $$root: true, type: "number", step: -1 })).toThrow(message);
+		expect(() => v.compile({ $$root: true, type: "number", step: NaN })).toThrow(message);
 	});
 
 	it("check step", () => {

--- a/test/rules/number.spec.js
+++ b/test/rules/number.spec.js
@@ -82,6 +82,19 @@ describe("Test rule: number", () => {
 		expect(check(20)).toEqual(true);
 	});
 
+	it("check step", () => {
+		const check = v.compile({ $$root: true, type: "number", step: 10 });
+		const message = "The '' field must be a multiple of 10.";
+
+		expect(check(8.5)).toEqual([{ type: "numberStep", expected: 10, actual: 8.5, message }]);
+		expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 10, actual: -5.5, message }]);
+		expect(check(15)).toEqual([{ type: "numberStep", expected: 10, actual: 15, message }]);
+		expect(check(0)).toEqual(true);
+		expect(check(-20)).toEqual(true);
+		expect(check(20)).toEqual(true);
+		expect(check(100)).toEqual(true);
+	});
+
 	it("check positive number", () => {
 		const check = v.compile({ $$root: true, type: "number", positive: true });
 		const message = "The '' field must be a positive number.";

--- a/test/typescript/messages.spec.ts
+++ b/test/typescript/messages.spec.ts
@@ -22,6 +22,7 @@ describe("TypeScript Definitions", () => {
 			expect(msg.numberEqual).toBeDefined();
 			expect(msg.numberNotEqual).toBeDefined();
 			expect(msg.numberInteger).toBeDefined();
+			expect(msg.numberStep).toBeDefined();
 			expect(msg.numberPositive).toBeDefined();
 			expect(msg.numberNegative).toBeDefined();
 			expect(msg.array).toBeDefined();

--- a/test/typescript/rules/number.spec.ts
+++ b/test/typescript/rules/number.spec.ts
@@ -93,6 +93,9 @@ describe('TypeScript Definitions', () => {
 			expect(check(8.5)).toEqual([{ type: "numberStep", expected: 10, actual: 8.5, message }]);
 			expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 10, actual: -5.5, message }]);
 			expect(check(15)).toEqual([{ type: "numberStep", expected: 10, actual: 15, message }]);
+			expect(check(NaN)).toEqual([{ type: "numberStep", expected: 10, actual: NaN, message }]);
+			expect(check(Infinity)).toEqual([{ type: "numberStep", expected: 10, actual: Infinity, message }]);
+
 			expect(check(0)).toEqual(true);
 			expect(check(-20)).toEqual(true);
 			expect(check(20)).toEqual(true);
@@ -106,6 +109,8 @@ describe('TypeScript Definitions', () => {
 			expect(check(1.1)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.1, message }]);
 			expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 0.2, actual: -5.5, message }]);
 			expect(check(0.20001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 0.20001, message }]);
+			expect(check(NaN)).toEqual([{ type: "numberStep", expected: 0.2, actual: NaN, message }]);
+			expect(check(Infinity)).toEqual([{ type: "numberStep", expected: 0.2, actual: Infinity, message }]);
 
 			expect(check(0)).toEqual(true);
 			expect(check(2)).toEqual(true);
@@ -113,7 +118,6 @@ describe('TypeScript Definitions', () => {
 			expect(check(-20.2)).toEqual(true);
 
 			expect(check(1.4000000001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.4000000001, message }]);
-			expect(check(1.40000000001)).toEqual(true); // will pass due to precision tolerance
 		});
 
 		it('check positive number', () => {

--- a/test/typescript/rules/number.spec.ts
+++ b/test/typescript/rules/number.spec.ts
@@ -93,8 +93,6 @@ describe('TypeScript Definitions', () => {
 			expect(check(8.5)).toEqual([{ type: "numberStep", expected: 10, actual: 8.5, message }]);
 			expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 10, actual: -5.5, message }]);
 			expect(check(15)).toEqual([{ type: "numberStep", expected: 10, actual: 15, message }]);
-			expect(check(NaN)).toEqual([{ type: "numberStep", expected: 10, actual: NaN, message }]);
-			expect(check(Infinity)).toEqual([{ type: "numberStep", expected: 10, actual: Infinity, message }]);
 
 			expect(check(0)).toEqual(true);
 			expect(check(-20)).toEqual(true);
@@ -109,8 +107,6 @@ describe('TypeScript Definitions', () => {
 			expect(check(1.1)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.1, message }]);
 			expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 0.2, actual: -5.5, message }]);
 			expect(check(0.20001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 0.20001, message }]);
-			expect(check(NaN)).toEqual([{ type: "numberStep", expected: 0.2, actual: NaN, message }]);
-			expect(check(Infinity)).toEqual([{ type: "numberStep", expected: 0.2, actual: Infinity, message }]);
 
 			expect(check(0)).toEqual(true);
 			expect(check(2)).toEqual(true);

--- a/test/typescript/rules/number.spec.ts
+++ b/test/typescript/rules/number.spec.ts
@@ -82,6 +82,8 @@ describe('TypeScript Definitions', () => {
 			const message = "Invalid 'number' schema. The 'step' field must be a positive number.";
 
 			expect(() => v.compile({ $$root: true, type: "number", step: 0 })).toThrow(message);
+			expect(() => v.compile({ $$root: true, type: "number", step: -1 })).toThrow(message);
+			expect(() => v.compile({ $$root: true, type: "number", step: NaN })).toThrow(message);
 		});
 
 		it('check step', () => {

--- a/test/typescript/rules/number.spec.ts
+++ b/test/typescript/rules/number.spec.ts
@@ -78,6 +78,19 @@ describe('TypeScript Definitions', () => {
 			expect(check(20)).toEqual(true);
 		});
 
+		it('check step', () => {
+			const check = v.compile({ $$root: true, type: 'number', step: 10 } as RuleNumber);
+			const message = 'The \'\' field must be a multiple of 10.';
+
+			expect(check(8.5)).toEqual([{ type: "numberStep", expected: 10, actual: 8.5, message }]);
+			expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 10, actual: -5.5, message }]);
+			expect(check(15)).toEqual([{ type: "numberStep", expected: 10, actual: 15, message }]);
+			expect(check(0)).toEqual(true);
+			expect(check(-20)).toEqual(true);
+			expect(check(20)).toEqual(true);
+			expect(check(100)).toEqual(true);
+		});
+
 		it('check positive number', () => {
 			const check = v.compile({ $$root: true, type: 'number', positive: true } as RuleNumber);
 			const message = 'The \'\' field must be a positive number.';

--- a/test/typescript/rules/number.spec.ts
+++ b/test/typescript/rules/number.spec.ts
@@ -78,9 +78,15 @@ describe('TypeScript Definitions', () => {
 			expect(check(20)).toEqual(true);
 		});
 
+		it("check schema's 'step' field type", () => {
+			const message = "Invalid 'number' schema. The 'step' field must be a positive number.";
+
+			expect(() => v.compile({ $$root: true, type: "number", step: 0 })).toThrow(message);
+		});
+
 		it('check step', () => {
 			const check = v.compile({ $$root: true, type: 'number', step: 10 } as RuleNumber);
-			const message = 'The \'\' field must be a multiple of 10.';
+			const message = "The '' field must be a multiple of 10.";
 
 			expect(check(8.5)).toEqual([{ type: "numberStep", expected: 10, actual: 8.5, message }]);
 			expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 10, actual: -5.5, message }]);
@@ -89,6 +95,23 @@ describe('TypeScript Definitions', () => {
 			expect(check(-20)).toEqual(true);
 			expect(check(20)).toEqual(true);
 			expect(check(100)).toEqual(true);
+		});
+
+		it("check step (float)", () => {
+			const check = v.compile({ $$root: true, type: "number", step: 0.2 } as RuleNumber);
+			const message = "The '' field must be a multiple of 0.2.";
+
+			expect(check(1.1)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.1, message }]);
+			expect(check(-5.5)).toEqual([{ type: "numberStep", expected: 0.2, actual: -5.5, message }]);
+			expect(check(0.20001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 0.20001, message }]);
+
+			expect(check(0)).toEqual(true);
+			expect(check(2)).toEqual(true);
+			expect(check(1.4)).toEqual(true);
+			expect(check(-20.2)).toEqual(true);
+
+			expect(check(1.4000000001)).toEqual([{ type: "numberStep", expected: 0.2, actual: 1.4000000001, message }]);
+			expect(check(1.40000000001)).toEqual(true); // will pass due to precision tolerance
 		});
 
 		it('check positive number', () => {


### PR DESCRIPTION
Implementing `step` property maintains consistency with the HTML5 range and number input types, which utilize the step attribute.