### PR TITLE
fix: ValidationSchema index signature conflict with ValidationSchemaM…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -933,7 +933,7 @@ export type ValidationSchema<T = any> = ValidationSchemaMetaKeys & {
 	/**
 	 * List of validation rules for each defined field
 	 */
-	[key in keyof T]: ValidationRule | undefined;
+	[key in Exclude<keyof T, `$$${string}`>]: ValidationRule | undefined;
 }
 
 


### PR DESCRIPTION
…etaKeys

Assigning an object with only $$strict to ValidationSchema produces a TypeScript error under stricter module resolution (TS 6):

```
Type '{ $$strict: true }' is not assignable to type 'ValidationSchema'.
  Property '$$strict' is incompatible with index signature.
    Type 'true' is not assignable to type 'ValidationRule | undefined'.
```

The root cause: `ValidationSchemaMetaKeys` declares `$$strict?: boolean | "remove"`, but the intersection with `{ [key in keyof T]: ValidationRule | undefined }` requires every string property — including `$$strict` — to satisfy `ValidationRule | undefined`. `boolean` is not a `ValidationRule`.

The fix excludes `$$`-prefixed keys from the mapped type, since they are already covered by `ValidationSchemaMetaKeys`:

```
[key in Exclude<keyof T, `$$${string}`>]: ValidationRule | undefined;
```

This is purely a type-level change with no runtime impact.
