### PR TITLE
fix: escape double-quotes in enum/contains/strict validator messages

### DIFF
--- a/lib/rules/array.js
+++ b/lib/rules/array.js
@@ -78,7 +78,7 @@ module.exports = function ({ schema, messages }, path, context) {
 		src.push(`
 			for (var i = 0; i < value.length; i++) {
 				if (${enumStr}.indexOf(value[i]) === -1) {
-					${this.makeError({ type: "arrayEnum", expected: "\"" + schema.enum.join(", ") + "\"", actual: "value[i]", messages })}
+					${this.makeError({ type: "arrayEnum", expected: JSON.stringify(schema.enum.join(", ")), actual: "value[i]", messages })}
 				}
 			}
 		`);

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -103,7 +103,7 @@ module.exports = function ({ schema, messages }, path, context) {
 				`);
 			} else {
 				sourceCode.push(`
-					${this.makeError({ type: "objectStrict", expected: "\"" + allowedProps.join(", ") + "\"", actual: "invalidProps.join(', ')", messages })}
+					${this.makeError({ type: "objectStrict", expected: JSON.stringify(allowedProps.join(", ")), actual: "invalidProps.join(', ')", messages })}
 				`);
 			}
 			sourceCode.push(`

--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -152,8 +152,8 @@ module.exports = function checkString({ schema, messages }, path, context) {
 
 	if (schema.contains != null) {
 		src.push(`
-			if (value.indexOf("${schema.contains}") === -1) {
-				${this.makeError({ type: "stringContains", expected: "\"" + schema.contains + "\"", actual: "origValue", messages })}
+			if (value.indexOf(${JSON.stringify(schema.contains)}) === -1) {
+				${this.makeError({ type: "stringContains", expected: JSON.stringify(schema.contains), actual: "origValue", messages })}
 			}
 		`);
 	}
@@ -162,7 +162,7 @@ module.exports = function checkString({ schema, messages }, path, context) {
 		const enumStr = JSON.stringify(schema.enum);
 		src.push(`
 			if (${enumStr}.indexOf(value) === -1) {
-				${this.makeError({ type: "stringEnum", expected: "\"" + schema.enum.join(", ") + "\"", actual: "origValue", messages })}
+				${this.makeError({ type: "stringEnum", expected: JSON.stringify(schema.enum.join(", ")), actual: "origValue", messages })}
 			}
 		`);
 	}

--- a/test/rules/array.spec.js
+++ b/test/rules/array.spec.js
@@ -94,6 +94,13 @@ describe("Test rule: array", () => {
 		expect(check(["male", "female", "human"])).toEqual([{ type: "arrayEnum", actual: "human", expected: "male, female", message: "The 'human' value in '' field does not match any of the 'male, female' values." }]);
 	});
 
+	it("check enum with a double-quote in a value", () => {
+		const check = v.compile({ $$root: true, type: "array", enum: ["male", "fe\"male"] });
+
+		expect(check(["human"])).toEqual([{ type: "arrayEnum", actual: "human", expected: "male, fe\"male", message: "The 'human' value in '' field does not match any of the 'male, fe\"male' values." }]);
+		expect(check(["fe\"male"])).toEqual(true);
+	});
+
 	it("check items", () => {
 		const check = v.compile({ $$root: true, type: "array", items: "string" });
 

--- a/test/rules/object.spec.js
+++ b/test/rules/object.spec.js
@@ -36,6 +36,14 @@ describe("Test rule: object", () => {
 		expect(o.a).toBe("John");
 	});
 
+	it("should check strict object with a double-quote in a property name", () => {
+		const check = v.compile({ $$root: true, type: "object", strict: true, props: {
+			"a\"b": { type: "string" }
+		} });
+		expect(check({ "a\"b": "John" })).toEqual(true);
+		expect(check({ "a\"b": "John", c: "Doe" })).toEqual([{ type: "objectStrict", actual: "c", expected: "a\"b", message: "The object '' contains forbidden keys: 'c'." }]);
+	});
+
 	it("should work with safe property name", () => {
 		const check = v.compile({ $$root: true, type: "object", properties: {
 			"read-only": "boolean",

--- a/test/rules/string.spec.js
+++ b/test/rules/string.spec.js
@@ -116,6 +116,13 @@ describe("Test rule: string", () => {
 		expect(check("Icebob")).toEqual(true);
 	});
 
+	it("check contains with a double-quote in the value", () => {
+		const check = v.compile({ $$root: true, type: "string", contains: "a\"b" });
+
+		expect(check("John")).toEqual([{ type: "stringContains", expected: "a\"b", actual: "John", message: "The '' field must contain the 'a\"b' text." }]);
+		expect(check("x a\"b y")).toEqual(true);
+	});
+
 	it("check enum", () => {
 		const check = v.compile({ $$root: true, type: "string", enum: ["male", "female"] });
 		const message = "The '' field does not match any of the allowed values.";
@@ -124,6 +131,15 @@ describe("Test rule: string", () => {
 		expect(check("human")).toEqual([{ type: "stringEnum", expected: "male, female", actual: "human", message }]);
 		expect(check("male")).toEqual(true);
 		expect(check("female")).toEqual(true);
+	});
+
+	it("check enum with a double-quote in a value", () => {
+		const check = v.compile({ $$root: true, type: "string", enum: ["male", "fe\"male"] });
+		const message = "The '' field does not match any of the allowed values.";
+
+		expect(check("human")).toEqual([{ type: "stringEnum", expected: "male, fe\"male", actual: "human", message }]);
+		expect(check("male")).toEqual(true);
+		expect(check("fe\"male")).toEqual(true);
 	});
 
 	it("check enum with enabled empty", () => {


### PR DESCRIPTION
#361 fixed a crash where an `enum` value containing a `"` produced invalid generated source. The same `"\"" + value + "\""` pattern is still used in a few other validators, so they crash the same way at compile time:

```js
const v = new (require("fastest-validator"))();

v.compile({ type: "string", enum: ["male", 'fe"male'] });   // SyntaxError: Unexpected identifier 'male'
v.compile({ type: "array",  enum: ["male", 'fe"male'] });   // SyntaxError: Unexpected identifier 'male'
v.compile({ type: "string", contains: 'a"b' });             // SyntaxError: missing ) after argument list
v.compile({ type: "object", strict: true, props: { 'a"b': { type: "string" } } }); // SyntaxError: Unexpected identifier 'b'
```

The error message's `expected` field (and, for `contains`, the `indexOf` argument) is built by concatenating the schema value into the generated function source with hand-written quotes, so a `"` in the value breaks the surrounding string literal and `new Function(...)` throws.

This switches those spots to `JSON.stringify`, the same fix as #361 and the same approach `equal` and the `array` `contains` rule already use. For values without a `"` the generated message is unchanged; values with a `"` now compile and the quote is preserved in the message:

```js
v.compile({ type: "string", enum: ["male", 'fe"male'] })("human");
// [{ type: "stringEnum", expected: 'male, fe"male', actual: "human", ... }]
```

Added regression tests for `stringEnum`, `arrayEnum`, `stringContains` and `objectStrict`. The full test suite passes.
